### PR TITLE
암호화 기능 추가

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3313,6 +3313,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-dialog",
  "tauri-plugin-opener",
+ "zeroize",
 ]
 
 [[package]]
@@ -5666,6 +5667,26 @@ dependencies = [
  "quote",
  "syn 2.0.117",
  "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -9,6 +9,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -471,6 +506,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -585,6 +630,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -636,6 +682,15 @@ checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
 dependencies = [
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -724,6 +779,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -1306,6 +1362,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
+]
+
+[[package]]
 name = "gio"
 version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1515,6 +1581,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "html5ever"
@@ -1799,6 +1874,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a588916bfdfd92e71cacef98a63d9b1f0d74d6599980d11894290e7ddefffcf7"
 dependencies = [
  "cfb",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -2380,6 +2464,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "open"
 version = "5.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2466,6 +2556,16 @@ name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
+
+[[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+ "hmac",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -2721,6 +2821,18 @@ dependencies = [
  "pin-project-lite",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
 ]
 
 [[package]]
@@ -3187,12 +3299,16 @@ dependencies = [
 name = "school-record-app"
 version = "0.0.0"
 dependencies = [
+ "aes-gcm",
  "base64 0.22.1",
  "chrono",
+ "pbkdf2",
+ "rand 0.8.6",
  "regex",
  "rusqlite",
  "serde",
  "serde_json",
+ "sha2",
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",
@@ -3594,6 +3710,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swift-rs"
@@ -4443,6 +4565,16 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "url"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -31,3 +31,4 @@ aes-gcm = "0.10"
 pbkdf2 = { version = "0.12", features = ["hmac"] }
 sha2 = "0.10"
 rand = "0.8"
+zeroize = { version = "1", features = ["derive"] }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -27,3 +27,7 @@ rusqlite = { version = "0.31", features = ["bundled"] }
 base64 = "0.22"
 chrono = { version = "0.4", features = ["clock"] }
 regex = "1"
+aes-gcm = "0.10"
+pbkdf2 = { version = "0.12", features = ["hmac"] }
+sha2 = "0.10"
+rand = "0.8"

--- a/src-tauri/src/commands/crypto.rs
+++ b/src-tauri/src/commands/crypto.rs
@@ -1,7 +1,8 @@
 use crate::commands::config::{get_config_impl, set_config_impl};
 use crate::crypto::{decrypt, derive_key, encrypt, generate_salt};
 use crate::state::{
-    clear_crypto_state, current_crypto_key, set_crypto_state, CryptoStateHandle, DbState,
+    clear_crypto_state, current_crypto_key, set_crypto_state, CryptoStateHandle, DbPathState,
+    DbState,
 };
 use base64::{engine::general_purpose::STANDARD as B64, Engine};
 use rusqlite::Connection;
@@ -186,14 +187,28 @@ pub(crate) fn unlock_encryption_impl(
     set_crypto_state(crypto, key, salt)
 }
 
+fn backup_db_file(db_path_state: &DbPathState, suffix: &str) -> Result<(), String> {
+    let guard = db_path_state.0.lock().map_err(|e| e.to_string())?;
+    let src = guard.as_ref().ok_or("열린 프로젝트가 없습니다.")?;
+    let parent = src.parent().ok_or("DB 파일의 상위 디렉토리를 찾을 수 없습니다.")?;
+    let stem = src.file_stem().and_then(|s| s.to_str()).unwrap_or("backup");
+    let ts = chrono::Local::now().format("%y%m%d-%H%M").to_string();
+    let bak_name = format!("{stem}.{ts}{suffix}.db.backup");
+    std::fs::copy(src, parent.join(bak_name)).map_err(|e| e.to_string())?;
+    Ok(())
+}
+
 pub(crate) fn enable_encryption_impl(
     conn: &Connection,
     crypto: &CryptoStateHandle,
+    db_path_state: &DbPathState,
     password: &str,
 ) -> Result<(), String> {
     if is_encryption_enabled(conn)? {
         return Err("이미 암호화가 활성화되어 있습니다.".to_string());
     }
+
+    backup_db_file(db_path_state, "-pre-encrypt")?;
 
     let salt = generate_salt();
     let key = derive_key(password, &salt);
@@ -214,8 +229,11 @@ pub(crate) fn enable_encryption_impl(
 pub(crate) fn disable_encryption_impl(
     conn: &Connection,
     crypto: &CryptoStateHandle,
+    db_path_state: &DbPathState,
 ) -> Result<(), String> {
     let key = resolve_data_key(conn, crypto)?.ok_or("암호화가 활성화되어 있지 않습니다.")?;
+
+    backup_db_file(db_path_state, "-pre-decrypt")?;
 
     run_transaction(conn, || {
         decrypt_all_data(conn, key)?;
@@ -289,20 +307,22 @@ pub fn unlock_encryption(
 pub fn enable_encryption(
     password: String,
     db: State<DbState>,
+    db_path: State<DbPathState>,
     crypto: State<CryptoStateHandle>,
 ) -> Result<(), String> {
     let password = Zeroizing::new(password);
     let guard = db.0.lock().map_err(|e| e.to_string())?;
-    enable_encryption_impl(db_conn(&guard)?, &crypto, &password)
+    enable_encryption_impl(db_conn(&guard)?, &crypto, &db_path, &password)
 }
 
 #[tauri::command]
 pub fn disable_encryption(
     db: State<DbState>,
+    db_path: State<DbPathState>,
     crypto: State<CryptoStateHandle>,
 ) -> Result<(), String> {
     let guard = db.0.lock().map_err(|e| e.to_string())?;
-    disable_encryption_impl(db_conn(&guard)?, &crypto)
+    disable_encryption_impl(db_conn(&guard)?, &crypto, &db_path)
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands/crypto.rs
+++ b/src-tauri/src/commands/crypto.rs
@@ -6,6 +6,7 @@ use crate::state::{
 use base64::{engine::general_purpose::STANDARD as B64, Engine};
 use rusqlite::Connection;
 use tauri::State;
+use zeroize::Zeroizing;
 
 const VERIFY_PLAINTEXT: &str = "school-record-verify";
 const KEY_ENCRYPTION_ENABLED: &str = "encryption_enabled";
@@ -279,6 +280,7 @@ pub fn unlock_encryption(
     db: State<DbState>,
     crypto: State<CryptoStateHandle>,
 ) -> Result<(), String> {
+    let password = Zeroizing::new(password);
     let guard = db.0.lock().map_err(|e| e.to_string())?;
     unlock_encryption_impl(db_conn(&guard)?, &crypto, &password)
 }
@@ -289,6 +291,7 @@ pub fn enable_encryption(
     db: State<DbState>,
     crypto: State<CryptoStateHandle>,
 ) -> Result<(), String> {
+    let password = Zeroizing::new(password);
     let guard = db.0.lock().map_err(|e| e.to_string())?;
     enable_encryption_impl(db_conn(&guard)?, &crypto, &password)
 }
@@ -309,6 +312,8 @@ pub fn change_encryption_password(
     db: State<DbState>,
     crypto: State<CryptoStateHandle>,
 ) -> Result<(), String> {
+    let old_password = Zeroizing::new(old_password);
+    let new_password = Zeroizing::new(new_password);
     let guard = db.0.lock().map_err(|e| e.to_string())?;
     change_encryption_password_impl(db_conn(&guard)?, &crypto, &old_password, &new_password)
 }

--- a/src-tauri/src/commands/crypto.rs
+++ b/src-tauri/src/commands/crypto.rs
@@ -1,0 +1,288 @@
+use crate::commands::config::{get_config_impl, set_config_impl};
+use crate::crypto::{decrypt, derive_key, encrypt, generate_salt};
+use crate::state::{CryptoStateHandle, DbState};
+use base64::{engine::general_purpose::STANDARD as B64, Engine};
+use rusqlite::Connection;
+use tauri::State;
+
+const VERIFY_PLAINTEXT: &str = "school-record-verify";
+const KEY_ENCRYPTION_ENABLED: &str = "encryption_enabled";
+const KEY_PBKDF2_SALT: &str = "encryption_pbkdf2_salt";
+const KEY_VERIFY_TOKEN: &str = "encryption_verify_token";
+
+#[derive(serde::Serialize)]
+pub struct EncryptionStatus {
+    pub enabled: bool,
+    pub unlocked: bool,
+}
+
+fn fetch_id_text(conn: &Connection, sql: &str) -> Result<Vec<(i64, String)>, String> {
+    let mut stmt = conn.prepare(sql).map_err(|e| e.to_string())?;
+    let rows = stmt
+        .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+        .map_err(|e| e.to_string())?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| e.to_string())?;
+    Ok(rows)
+}
+
+fn encrypt_all_data(conn: &Connection, key: [u8; 32]) -> Result<(), String> {
+    let students = fetch_id_text(conn, "SELECT id, name FROM Student")?;
+    for (id, name) in students {
+        let encrypted = encrypt(&name, &key)?;
+        conn.execute(
+            "UPDATE Student SET name=?1 WHERE id=?2",
+            rusqlite::params![encrypted, id],
+        )
+        .map_err(|e| e.to_string())?;
+    }
+
+    let records =
+        fetch_id_text(conn, "SELECT id, content FROM ActivityRecord WHERE content != ''")?;
+    for (id, content) in records {
+        let encrypted = encrypt(&content, &key)?;
+        conn.execute(
+            "UPDATE ActivityRecord SET content=?1 WHERE id=?2",
+            rusqlite::params![encrypted, id],
+        )
+        .map_err(|e| e.to_string())?;
+    }
+
+    let history = fetch_id_text(
+        conn,
+        "SELECT id, content FROM ActivityRecordHistory WHERE content != ''",
+    )?;
+    for (id, content) in history {
+        let encrypted = encrypt(&content, &key)?;
+        conn.execute(
+            "UPDATE ActivityRecordHistory SET content=?1 WHERE id=?2",
+            rusqlite::params![encrypted, id],
+        )
+        .map_err(|e| e.to_string())?;
+    }
+
+    Ok(())
+}
+
+fn decrypt_all_data(conn: &Connection, key: [u8; 32]) -> Result<(), String> {
+    let students = fetch_id_text(conn, "SELECT id, name FROM Student")?;
+    for (id, encrypted_name) in students {
+        let plain = decrypt(&encrypted_name, &key)?;
+        conn.execute(
+            "UPDATE Student SET name=?1 WHERE id=?2",
+            rusqlite::params![plain, id],
+        )
+        .map_err(|e| e.to_string())?;
+    }
+
+    let records =
+        fetch_id_text(conn, "SELECT id, content FROM ActivityRecord WHERE content != ''")?;
+    for (id, content) in records {
+        let plain = decrypt(&content, &key)?;
+        conn.execute(
+            "UPDATE ActivityRecord SET content=?1 WHERE id=?2",
+            rusqlite::params![plain, id],
+        )
+        .map_err(|e| e.to_string())?;
+    }
+
+    let history = fetch_id_text(
+        conn,
+        "SELECT id, content FROM ActivityRecordHistory WHERE content != ''",
+    )?;
+    for (id, content) in history {
+        let plain = decrypt(&content, &key)?;
+        conn.execute(
+            "UPDATE ActivityRecordHistory SET content=?1 WHERE id=?2",
+            rusqlite::params![plain, id],
+        )
+        .map_err(|e| e.to_string())?;
+    }
+
+    Ok(())
+}
+
+#[tauri::command]
+pub fn get_encryption_status(
+    db: State<DbState>,
+    crypto: State<CryptoStateHandle>,
+) -> Result<EncryptionStatus, String> {
+    let enabled = {
+        let guard = db.0.lock().map_err(|e| e.to_string())?;
+        let conn = guard.as_ref().ok_or("DB가 열려있지 않습니다.")?;
+        get_config_impl(conn, KEY_ENCRYPTION_ENABLED)?.as_deref() == Some("true")
+    };
+    let unlocked = {
+        let guard = crypto.lock().map_err(|e| e.to_string())?;
+        guard.key.is_some()
+    };
+    Ok(EncryptionStatus { enabled, unlocked })
+}
+
+#[tauri::command]
+pub fn unlock_encryption(
+    password: String,
+    db: State<DbState>,
+    crypto: State<CryptoStateHandle>,
+) -> Result<(), String> {
+    let (salt, verify_token) = {
+        let guard = db.0.lock().map_err(|e| e.to_string())?;
+        let conn = guard.as_ref().ok_or("DB가 열려있지 않습니다.")?;
+        let salt_b64 = get_config_impl(conn, KEY_PBKDF2_SALT)?
+            .ok_or("암호화 설정이 없습니다.")?;
+        let salt = B64.decode(&salt_b64).map_err(|e| format!("salt 디코딩 실패: {e}"))?;
+        let token = get_config_impl(conn, KEY_VERIFY_TOKEN)?
+            .ok_or("검증 토큰이 없습니다.")?;
+        (salt, token)
+    };
+
+    let key = derive_key(&password, &salt);
+
+    let verified = decrypt(&verify_token, &key)
+        .map(|s| s == VERIFY_PLAINTEXT)
+        .unwrap_or(false);
+    if !verified {
+        return Err("비밀번호가 올바르지 않습니다.".to_string());
+    }
+
+    let mut guard = crypto.lock().map_err(|e| e.to_string())?;
+    guard.key = Some(key);
+    guard.salt = Some(salt);
+    Ok(())
+}
+
+#[tauri::command]
+pub fn enable_encryption(
+    password: String,
+    db: State<DbState>,
+    crypto: State<CryptoStateHandle>,
+) -> Result<(), String> {
+    let salt = generate_salt();
+    let key = derive_key(&password, &salt);
+    let salt_b64 = B64.encode(salt);
+    let verify_token = encrypt(VERIFY_PLAINTEXT, &key)?;
+
+    {
+        let guard = db.0.lock().map_err(|e| e.to_string())?;
+        let conn = guard.as_ref().ok_or("DB가 열려있지 않습니다.")?;
+
+        if get_config_impl(conn, KEY_ENCRYPTION_ENABLED)?.as_deref() == Some("true") {
+            return Err("이미 암호화가 활성화되어 있습니다.".to_string());
+        }
+
+        conn.execute_batch("BEGIN").map_err(|e| e.to_string())?;
+        let result = (|| -> Result<(), String> {
+            encrypt_all_data(conn, key)?;
+            set_config_impl(conn, KEY_PBKDF2_SALT, &salt_b64)?;
+            set_config_impl(conn, KEY_VERIFY_TOKEN, &verify_token)?;
+            set_config_impl(conn, KEY_ENCRYPTION_ENABLED, "true")?;
+            Ok(())
+        })();
+        match result {
+            Ok(_) => conn.execute_batch("COMMIT").map_err(|e| e.to_string())?,
+            Err(e) => {
+                let _ = conn.execute_batch("ROLLBACK");
+                return Err(e);
+            }
+        }
+    }
+
+    let mut guard = crypto.lock().map_err(|e| e.to_string())?;
+    guard.key = Some(key);
+    guard.salt = Some(B64.decode(&salt_b64).unwrap_or_default());
+    Ok(())
+}
+
+#[tauri::command]
+pub fn disable_encryption(
+    db: State<DbState>,
+    crypto: State<CryptoStateHandle>,
+) -> Result<(), String> {
+    let key = {
+        let guard = crypto.lock().map_err(|e| e.to_string())?;
+        guard.key.ok_or("암호화가 잠금 상태입니다.")?
+    };
+
+    {
+        let guard = db.0.lock().map_err(|e| e.to_string())?;
+        let conn = guard.as_ref().ok_or("DB가 열려있지 않습니다.")?;
+        conn.execute_batch("BEGIN").map_err(|e| e.to_string())?;
+        let result = (|| -> Result<(), String> {
+            decrypt_all_data(conn, key)?;
+            conn.execute(
+                "DELETE FROM APP_CONFIGS WHERE config_key IN (?1, ?2, ?3)",
+                rusqlite::params![KEY_ENCRYPTION_ENABLED, KEY_PBKDF2_SALT, KEY_VERIFY_TOKEN],
+            )
+            .map_err(|e| e.to_string())?;
+            Ok(())
+        })();
+        match result {
+            Ok(_) => conn.execute_batch("COMMIT").map_err(|e| e.to_string())?,
+            Err(e) => {
+                let _ = conn.execute_batch("ROLLBACK");
+                return Err(e);
+            }
+        }
+    }
+
+    let mut guard = crypto.lock().map_err(|e| e.to_string())?;
+    guard.key = None;
+    guard.salt = None;
+    Ok(())
+}
+
+#[tauri::command]
+pub fn change_encryption_password(
+    old_password: String,
+    new_password: String,
+    db: State<DbState>,
+    crypto: State<CryptoStateHandle>,
+) -> Result<(), String> {
+    let (salt, verify_token) = {
+        let guard = db.0.lock().map_err(|e| e.to_string())?;
+        let conn = guard.as_ref().ok_or("DB가 열려있지 않습니다.")?;
+        let salt_b64 = get_config_impl(conn, KEY_PBKDF2_SALT)?
+            .ok_or("암호화 설정이 없습니다.")?;
+        let salt = B64.decode(&salt_b64).map_err(|e| e.to_string())?;
+        let token = get_config_impl(conn, KEY_VERIFY_TOKEN)?
+            .ok_or("검증 토큰이 없습니다.")?;
+        (salt, token)
+    };
+    let old_key = derive_key(&old_password, &salt);
+    let verified = decrypt(&verify_token, &old_key)
+        .map(|s| s == VERIFY_PLAINTEXT)
+        .unwrap_or(false);
+    if !verified {
+        return Err("현재 비밀번호가 올바르지 않습니다.".to_string());
+    }
+
+    let new_salt = generate_salt();
+    let new_key = derive_key(&new_password, &new_salt);
+    let new_salt_b64 = B64.encode(new_salt);
+    let new_verify_token = encrypt(VERIFY_PLAINTEXT, &new_key)?;
+
+    {
+        let guard = db.0.lock().map_err(|e| e.to_string())?;
+        let conn = guard.as_ref().ok_or("DB가 열려있지 않습니다.")?;
+        conn.execute_batch("BEGIN").map_err(|e| e.to_string())?;
+        let result = (|| -> Result<(), String> {
+            decrypt_all_data(conn, old_key)?;
+            encrypt_all_data(conn, new_key)?;
+            set_config_impl(conn, KEY_PBKDF2_SALT, &new_salt_b64)?;
+            set_config_impl(conn, KEY_VERIFY_TOKEN, &new_verify_token)?;
+            Ok(())
+        })();
+        match result {
+            Ok(_) => conn.execute_batch("COMMIT").map_err(|e| e.to_string())?,
+            Err(e) => {
+                let _ = conn.execute_batch("ROLLBACK");
+                return Err(e);
+            }
+        }
+    }
+
+    let mut guard = crypto.lock().map_err(|e| e.to_string())?;
+    guard.key = Some(new_key);
+    guard.salt = Some(B64.decode(&new_salt_b64).unwrap_or_default());
+    Ok(())
+}

--- a/src-tauri/src/commands/crypto.rs
+++ b/src-tauri/src/commands/crypto.rs
@@ -251,6 +251,7 @@ pub(crate) fn disable_encryption_impl(
 pub(crate) fn change_encryption_password_impl(
     conn: &Connection,
     crypto: &CryptoStateHandle,
+    db_path_state: &DbPathState,
     old_password: &str,
     new_password: &str,
 ) -> Result<(), String> {
@@ -261,6 +262,9 @@ pub(crate) fn change_encryption_password_impl(
         &verify_token,
         "현재 비밀번호가 올바르지 않습니다.",
     )?;
+
+    backup_db_file(db_path_state, "-pre-reencrypt")?;
+
     let new_salt = generate_salt();
     let new_key = derive_key(new_password, &new_salt);
     let new_salt_b64 = B64.encode(new_salt);
@@ -330,10 +334,11 @@ pub fn change_encryption_password(
     old_password: String,
     new_password: String,
     db: State<DbState>,
+    db_path: State<DbPathState>,
     crypto: State<CryptoStateHandle>,
 ) -> Result<(), String> {
     let old_password = Zeroizing::new(old_password);
     let new_password = Zeroizing::new(new_password);
     let guard = db.0.lock().map_err(|e| e.to_string())?;
-    change_encryption_password_impl(db_conn(&guard)?, &crypto, &old_password, &new_password)
+    change_encryption_password_impl(db_conn(&guard)?, &crypto, &db_path, &old_password, &new_password)
 }

--- a/src-tauri/src/commands/crypto.rs
+++ b/src-tauri/src/commands/crypto.rs
@@ -191,14 +191,14 @@ pub(crate) fn enable_encryption_impl(
     crypto: &CryptoStateHandle,
     password: &str,
 ) -> Result<(), String> {
+    if is_encryption_enabled(conn)? {
+        return Err("이미 암호화가 활성화되어 있습니다.".to_string());
+    }
+
     let salt = generate_salt();
     let key = derive_key(password, &salt);
     let salt_b64 = B64.encode(salt);
     let verify_token = encrypt(VERIFY_PLAINTEXT, &key)?;
-
-    if is_encryption_enabled(conn)? {
-        return Err("이미 암호화가 활성화되어 있습니다.".to_string());
-    }
 
     run_transaction(conn, || {
         encrypt_all_data(conn, key)?;

--- a/src-tauri/src/commands/crypto.rs
+++ b/src-tauri/src/commands/crypto.rs
@@ -1,5 +1,5 @@
 use crate::commands::config::{get_config_impl, set_config_impl};
-use crate::crypto::{decrypt, derive_key, encrypt, generate_salt};
+use crate::crypto::{decrypt, derive_key, encrypt, generate_salt, maybe_decrypt, maybe_encrypt};
 use crate::state::{
     clear_crypto_state, current_crypto_key, set_crypto_state, CryptoStateHandle, DbPathState,
     DbState,
@@ -102,8 +102,8 @@ fn transform_all_data(
         let update_sql = update_column_sql(spec);
         for (id, value) in rows {
             let transformed = match transform {
-                DataTransform::Encrypt => encrypt(&value, &key)?,
-                DataTransform::Decrypt => decrypt(&value, &key)?,
+                DataTransform::Encrypt => maybe_encrypt(&value, Some(key))?,
+                DataTransform::Decrypt => maybe_decrypt(value, Some(key))?,
             };
             conn.execute(&update_sql, rusqlite::params![transformed, id])
                 .map_err(|e| e.to_string())?;

--- a/src-tauri/src/commands/crypto.rs
+++ b/src-tauri/src/commands/crypto.rs
@@ -1,6 +1,8 @@
 use crate::commands::config::{get_config_impl, set_config_impl};
 use crate::crypto::{decrypt, derive_key, encrypt, generate_salt};
-use crate::state::{CryptoStateHandle, DbState};
+use crate::state::{
+    clear_crypto_state, current_crypto_key, set_crypto_state, CryptoStateHandle, DbState,
+};
 use base64::{engine::general_purpose::STANDARD as B64, Engine};
 use rusqlite::Connection;
 use tauri::State;
@@ -16,6 +18,53 @@ pub struct EncryptionStatus {
     pub unlocked: bool,
 }
 
+#[derive(Clone, Copy)]
+enum DataTransform {
+    Encrypt,
+    Decrypt,
+}
+
+struct EncryptedColumn {
+    table: &'static str,
+    column: &'static str,
+    skip_empty: bool,
+}
+
+const ENCRYPTED_COLUMNS: &[EncryptedColumn] = &[
+    EncryptedColumn {
+        table: "Student",
+        column: "name",
+        skip_empty: false,
+    },
+    EncryptedColumn {
+        table: "ActivityRecord",
+        column: "content",
+        skip_empty: true,
+    },
+    EncryptedColumn {
+        table: "ActivityRecordHistory",
+        column: "content",
+        skip_empty: true,
+    },
+];
+
+fn run_transaction<T>(
+    conn: &Connection,
+    action: impl FnOnce() -> Result<T, String>,
+) -> Result<T, String> {
+    conn.execute_batch("BEGIN").map_err(|e| e.to_string())?;
+    match action() {
+        Ok(value) => {
+            conn.execute_batch("COMMIT").map_err(|e| e.to_string())?;
+            Ok(value)
+        }
+        Err(e) => {
+            let _ = conn.execute_batch("ROLLBACK");
+            Err(e)
+        }
+    }
+}
+
 fn fetch_id_text(conn: &Connection, sql: &str) -> Result<Vec<(i64, String)>, String> {
     let mut stmt = conn.prepare(sql).map_err(|e| e.to_string())?;
     let rows = stmt
@@ -26,80 +75,193 @@ fn fetch_id_text(conn: &Connection, sql: &str) -> Result<Vec<(i64, String)>, Str
     Ok(rows)
 }
 
-fn encrypt_all_data(conn: &Connection, key: [u8; 32]) -> Result<(), String> {
-    let students = fetch_id_text(conn, "SELECT id, name FROM Student")?;
-    for (id, name) in students {
-        let encrypted = encrypt(&name, &key)?;
-        conn.execute(
-            "UPDATE Student SET name=?1 WHERE id=?2",
-            rusqlite::params![encrypted, id],
+fn select_column_sql(spec: &EncryptedColumn) -> String {
+    if spec.skip_empty {
+        format!(
+            "SELECT id, {} FROM {} WHERE {} != ''",
+            spec.column, spec.table, spec.column
         )
-        .map_err(|e| e.to_string())?;
+    } else {
+        format!("SELECT id, {} FROM {}", spec.column, spec.table)
     }
+}
 
-    let records =
-        fetch_id_text(conn, "SELECT id, content FROM ActivityRecord WHERE content != ''")?;
-    for (id, content) in records {
-        let encrypted = encrypt(&content, &key)?;
-        conn.execute(
-            "UPDATE ActivityRecord SET content=?1 WHERE id=?2",
-            rusqlite::params![encrypted, id],
-        )
-        .map_err(|e| e.to_string())?;
+fn update_column_sql(spec: &EncryptedColumn) -> String {
+    format!("UPDATE {} SET {}=?1 WHERE id=?2", spec.table, spec.column)
+}
+
+fn transform_all_data(
+    conn: &Connection,
+    key: [u8; 32],
+    transform: DataTransform,
+) -> Result<(), String> {
+    for spec in ENCRYPTED_COLUMNS {
+        let rows = fetch_id_text(conn, &select_column_sql(spec))?;
+        let update_sql = update_column_sql(spec);
+        for (id, value) in rows {
+            let transformed = match transform {
+                DataTransform::Encrypt => encrypt(&value, &key)?,
+                DataTransform::Decrypt => decrypt(&value, &key)?,
+            };
+            conn.execute(&update_sql, rusqlite::params![transformed, id])
+                .map_err(|e| e.to_string())?;
+        }
     }
-
-    let history = fetch_id_text(
-        conn,
-        "SELECT id, content FROM ActivityRecordHistory WHERE content != ''",
-    )?;
-    for (id, content) in history {
-        let encrypted = encrypt(&content, &key)?;
-        conn.execute(
-            "UPDATE ActivityRecordHistory SET content=?1 WHERE id=?2",
-            rusqlite::params![encrypted, id],
-        )
-        .map_err(|e| e.to_string())?;
-    }
-
     Ok(())
 }
 
-fn decrypt_all_data(conn: &Connection, key: [u8; 32]) -> Result<(), String> {
-    let students = fetch_id_text(conn, "SELECT id, name FROM Student")?;
-    for (id, encrypted_name) in students {
-        let plain = decrypt(&encrypted_name, &key)?;
-        conn.execute(
-            "UPDATE Student SET name=?1 WHERE id=?2",
-            rusqlite::params![plain, id],
-        )
-        .map_err(|e| e.to_string())?;
+pub(crate) fn encrypt_all_data(conn: &Connection, key: [u8; 32]) -> Result<(), String> {
+    transform_all_data(conn, key, DataTransform::Encrypt)
+}
+
+pub(crate) fn decrypt_all_data(conn: &Connection, key: [u8; 32]) -> Result<(), String> {
+    transform_all_data(conn, key, DataTransform::Decrypt)
+}
+
+pub(crate) fn is_encryption_enabled(conn: &Connection) -> Result<bool, String> {
+    Ok(get_config_impl(conn, KEY_ENCRYPTION_ENABLED)?.as_deref() == Some("true"))
+}
+
+fn encryption_material(conn: &Connection) -> Result<(Vec<u8>, String), String> {
+    let salt_b64 = get_config_impl(conn, KEY_PBKDF2_SALT)?.ok_or("암호화 설정이 없습니다.")?;
+    let salt = B64
+        .decode(&salt_b64)
+        .map_err(|e| format!("salt 디코딩 실패: {e}"))?;
+    let token = get_config_impl(conn, KEY_VERIFY_TOKEN)?.ok_or("검증 토큰이 없습니다.")?;
+    Ok((salt, token))
+}
+
+fn verify_password(
+    password: &str,
+    salt: &[u8],
+    verify_token: &str,
+    error_message: &str,
+) -> Result<[u8; 32], String> {
+    let key = derive_key(password, salt);
+    let verified = decrypt(verify_token, &key)
+        .map(|s| s == VERIFY_PLAINTEXT)
+        .unwrap_or(false);
+    if verified {
+        Ok(key)
+    } else {
+        Err(error_message.to_string())
+    }
+}
+
+pub(crate) fn resolve_data_key(
+    conn: &Connection,
+    crypto: &CryptoStateHandle,
+) -> Result<Option<[u8; 32]>, String> {
+    if !is_encryption_enabled(conn)? {
+        return Ok(None);
     }
 
-    let records =
-        fetch_id_text(conn, "SELECT id, content FROM ActivityRecord WHERE content != ''")?;
-    for (id, content) in records {
-        let plain = decrypt(&content, &key)?;
-        conn.execute(
-            "UPDATE ActivityRecord SET content=?1 WHERE id=?2",
-            rusqlite::params![plain, id],
-        )
-        .map_err(|e| e.to_string())?;
-    }
+    current_crypto_key(crypto)?
+        .map(Some)
+        .ok_or_else(|| "암호화가 잠금 상태입니다.".to_string())
+}
 
-    let history = fetch_id_text(
-        conn,
-        "SELECT id, content FROM ActivityRecordHistory WHERE content != ''",
+pub(crate) fn get_encryption_status_impl(
+    conn: &Connection,
+    crypto: &CryptoStateHandle,
+) -> Result<EncryptionStatus, String> {
+    let enabled = is_encryption_enabled(conn)?;
+    let unlocked = enabled && current_crypto_key(crypto)?.is_some();
+    Ok(EncryptionStatus { enabled, unlocked })
+}
+
+pub(crate) fn unlock_encryption_impl(
+    conn: &Connection,
+    crypto: &CryptoStateHandle,
+    password: &str,
+) -> Result<(), String> {
+    let (salt, verify_token) = encryption_material(conn)?;
+    let key = verify_password(
+        password,
+        &salt,
+        &verify_token,
+        "비밀번호가 올바르지 않습니다.",
     )?;
-    for (id, content) in history {
-        let plain = decrypt(&content, &key)?;
-        conn.execute(
-            "UPDATE ActivityRecordHistory SET content=?1 WHERE id=?2",
-            rusqlite::params![plain, id],
-        )
-        .map_err(|e| e.to_string())?;
+    set_crypto_state(crypto, key, salt)
+}
+
+pub(crate) fn enable_encryption_impl(
+    conn: &Connection,
+    crypto: &CryptoStateHandle,
+    password: &str,
+) -> Result<(), String> {
+    let salt = generate_salt();
+    let key = derive_key(password, &salt);
+    let salt_b64 = B64.encode(salt);
+    let verify_token = encrypt(VERIFY_PLAINTEXT, &key)?;
+
+    if is_encryption_enabled(conn)? {
+        return Err("이미 암호화가 활성화되어 있습니다.".to_string());
     }
 
-    Ok(())
+    run_transaction(conn, || {
+        encrypt_all_data(conn, key)?;
+        set_config_impl(conn, KEY_PBKDF2_SALT, &salt_b64)?;
+        set_config_impl(conn, KEY_VERIFY_TOKEN, &verify_token)?;
+        set_config_impl(conn, KEY_ENCRYPTION_ENABLED, "true")?;
+        Ok(())
+    })?;
+
+    set_crypto_state(crypto, key, salt.to_vec())
+}
+
+pub(crate) fn disable_encryption_impl(
+    conn: &Connection,
+    crypto: &CryptoStateHandle,
+) -> Result<(), String> {
+    let key = resolve_data_key(conn, crypto)?.ok_or("암호화가 활성화되어 있지 않습니다.")?;
+
+    run_transaction(conn, || {
+        decrypt_all_data(conn, key)?;
+        conn.execute(
+            "DELETE FROM APP_CONFIGS WHERE config_key IN (?1, ?2, ?3)",
+            rusqlite::params![KEY_ENCRYPTION_ENABLED, KEY_PBKDF2_SALT, KEY_VERIFY_TOKEN],
+        )
+        .map_err(|e| e.to_string())?;
+        Ok(())
+    })?;
+
+    clear_crypto_state(crypto)
+}
+
+pub(crate) fn change_encryption_password_impl(
+    conn: &Connection,
+    crypto: &CryptoStateHandle,
+    old_password: &str,
+    new_password: &str,
+) -> Result<(), String> {
+    let (salt, verify_token) = encryption_material(conn)?;
+    let old_key = verify_password(
+        old_password,
+        &salt,
+        &verify_token,
+        "현재 비밀번호가 올바르지 않습니다.",
+    )?;
+    let new_salt = generate_salt();
+    let new_key = derive_key(new_password, &new_salt);
+    let new_salt_b64 = B64.encode(new_salt);
+    let new_verify_token = encrypt(VERIFY_PLAINTEXT, &new_key)?;
+
+    run_transaction(conn, || {
+        decrypt_all_data(conn, old_key)?;
+        encrypt_all_data(conn, new_key)?;
+        set_config_impl(conn, KEY_PBKDF2_SALT, &new_salt_b64)?;
+        set_config_impl(conn, KEY_VERIFY_TOKEN, &new_verify_token)?;
+        Ok(())
+    })?;
+
+    set_crypto_state(crypto, new_key, new_salt.to_vec())
+}
+
+fn db_conn<'a>(guard: &'a Option<Connection>) -> Result<&'a Connection, String> {
+    guard
+        .as_ref()
+        .ok_or_else(|| "DB가 열려있지 않습니다.".to_string())
 }
 
 #[tauri::command]
@@ -107,16 +269,8 @@ pub fn get_encryption_status(
     db: State<DbState>,
     crypto: State<CryptoStateHandle>,
 ) -> Result<EncryptionStatus, String> {
-    let enabled = {
-        let guard = db.0.lock().map_err(|e| e.to_string())?;
-        let conn = guard.as_ref().ok_or("DB가 열려있지 않습니다.")?;
-        get_config_impl(conn, KEY_ENCRYPTION_ENABLED)?.as_deref() == Some("true")
-    };
-    let unlocked = {
-        let guard = crypto.lock().map_err(|e| e.to_string())?;
-        guard.key.is_some()
-    };
-    Ok(EncryptionStatus { enabled, unlocked })
+    let guard = db.0.lock().map_err(|e| e.to_string())?;
+    get_encryption_status_impl(db_conn(&guard)?, &crypto)
 }
 
 #[tauri::command]
@@ -125,30 +279,8 @@ pub fn unlock_encryption(
     db: State<DbState>,
     crypto: State<CryptoStateHandle>,
 ) -> Result<(), String> {
-    let (salt, verify_token) = {
-        let guard = db.0.lock().map_err(|e| e.to_string())?;
-        let conn = guard.as_ref().ok_or("DB가 열려있지 않습니다.")?;
-        let salt_b64 = get_config_impl(conn, KEY_PBKDF2_SALT)?
-            .ok_or("암호화 설정이 없습니다.")?;
-        let salt = B64.decode(&salt_b64).map_err(|e| format!("salt 디코딩 실패: {e}"))?;
-        let token = get_config_impl(conn, KEY_VERIFY_TOKEN)?
-            .ok_or("검증 토큰이 없습니다.")?;
-        (salt, token)
-    };
-
-    let key = derive_key(&password, &salt);
-
-    let verified = decrypt(&verify_token, &key)
-        .map(|s| s == VERIFY_PLAINTEXT)
-        .unwrap_or(false);
-    if !verified {
-        return Err("비밀번호가 올바르지 않습니다.".to_string());
-    }
-
-    let mut guard = crypto.lock().map_err(|e| e.to_string())?;
-    guard.key = Some(key);
-    guard.salt = Some(salt);
-    Ok(())
+    let guard = db.0.lock().map_err(|e| e.to_string())?;
+    unlock_encryption_impl(db_conn(&guard)?, &crypto, &password)
 }
 
 #[tauri::command]
@@ -157,40 +289,8 @@ pub fn enable_encryption(
     db: State<DbState>,
     crypto: State<CryptoStateHandle>,
 ) -> Result<(), String> {
-    let salt = generate_salt();
-    let key = derive_key(&password, &salt);
-    let salt_b64 = B64.encode(salt);
-    let verify_token = encrypt(VERIFY_PLAINTEXT, &key)?;
-
-    {
-        let guard = db.0.lock().map_err(|e| e.to_string())?;
-        let conn = guard.as_ref().ok_or("DB가 열려있지 않습니다.")?;
-
-        if get_config_impl(conn, KEY_ENCRYPTION_ENABLED)?.as_deref() == Some("true") {
-            return Err("이미 암호화가 활성화되어 있습니다.".to_string());
-        }
-
-        conn.execute_batch("BEGIN").map_err(|e| e.to_string())?;
-        let result = (|| -> Result<(), String> {
-            encrypt_all_data(conn, key)?;
-            set_config_impl(conn, KEY_PBKDF2_SALT, &salt_b64)?;
-            set_config_impl(conn, KEY_VERIFY_TOKEN, &verify_token)?;
-            set_config_impl(conn, KEY_ENCRYPTION_ENABLED, "true")?;
-            Ok(())
-        })();
-        match result {
-            Ok(_) => conn.execute_batch("COMMIT").map_err(|e| e.to_string())?,
-            Err(e) => {
-                let _ = conn.execute_batch("ROLLBACK");
-                return Err(e);
-            }
-        }
-    }
-
-    let mut guard = crypto.lock().map_err(|e| e.to_string())?;
-    guard.key = Some(key);
-    guard.salt = Some(B64.decode(&salt_b64).unwrap_or_default());
-    Ok(())
+    let guard = db.0.lock().map_err(|e| e.to_string())?;
+    enable_encryption_impl(db_conn(&guard)?, &crypto, &password)
 }
 
 #[tauri::command]
@@ -198,37 +298,8 @@ pub fn disable_encryption(
     db: State<DbState>,
     crypto: State<CryptoStateHandle>,
 ) -> Result<(), String> {
-    let key = {
-        let guard = crypto.lock().map_err(|e| e.to_string())?;
-        guard.key.ok_or("암호화가 잠금 상태입니다.")?
-    };
-
-    {
-        let guard = db.0.lock().map_err(|e| e.to_string())?;
-        let conn = guard.as_ref().ok_or("DB가 열려있지 않습니다.")?;
-        conn.execute_batch("BEGIN").map_err(|e| e.to_string())?;
-        let result = (|| -> Result<(), String> {
-            decrypt_all_data(conn, key)?;
-            conn.execute(
-                "DELETE FROM APP_CONFIGS WHERE config_key IN (?1, ?2, ?3)",
-                rusqlite::params![KEY_ENCRYPTION_ENABLED, KEY_PBKDF2_SALT, KEY_VERIFY_TOKEN],
-            )
-            .map_err(|e| e.to_string())?;
-            Ok(())
-        })();
-        match result {
-            Ok(_) => conn.execute_batch("COMMIT").map_err(|e| e.to_string())?,
-            Err(e) => {
-                let _ = conn.execute_batch("ROLLBACK");
-                return Err(e);
-            }
-        }
-    }
-
-    let mut guard = crypto.lock().map_err(|e| e.to_string())?;
-    guard.key = None;
-    guard.salt = None;
-    Ok(())
+    let guard = db.0.lock().map_err(|e| e.to_string())?;
+    disable_encryption_impl(db_conn(&guard)?, &crypto)
 }
 
 #[tauri::command]
@@ -238,51 +309,6 @@ pub fn change_encryption_password(
     db: State<DbState>,
     crypto: State<CryptoStateHandle>,
 ) -> Result<(), String> {
-    let (salt, verify_token) = {
-        let guard = db.0.lock().map_err(|e| e.to_string())?;
-        let conn = guard.as_ref().ok_or("DB가 열려있지 않습니다.")?;
-        let salt_b64 = get_config_impl(conn, KEY_PBKDF2_SALT)?
-            .ok_or("암호화 설정이 없습니다.")?;
-        let salt = B64.decode(&salt_b64).map_err(|e| e.to_string())?;
-        let token = get_config_impl(conn, KEY_VERIFY_TOKEN)?
-            .ok_or("검증 토큰이 없습니다.")?;
-        (salt, token)
-    };
-    let old_key = derive_key(&old_password, &salt);
-    let verified = decrypt(&verify_token, &old_key)
-        .map(|s| s == VERIFY_PLAINTEXT)
-        .unwrap_or(false);
-    if !verified {
-        return Err("현재 비밀번호가 올바르지 않습니다.".to_string());
-    }
-
-    let new_salt = generate_salt();
-    let new_key = derive_key(&new_password, &new_salt);
-    let new_salt_b64 = B64.encode(new_salt);
-    let new_verify_token = encrypt(VERIFY_PLAINTEXT, &new_key)?;
-
-    {
-        let guard = db.0.lock().map_err(|e| e.to_string())?;
-        let conn = guard.as_ref().ok_or("DB가 열려있지 않습니다.")?;
-        conn.execute_batch("BEGIN").map_err(|e| e.to_string())?;
-        let result = (|| -> Result<(), String> {
-            decrypt_all_data(conn, old_key)?;
-            encrypt_all_data(conn, new_key)?;
-            set_config_impl(conn, KEY_PBKDF2_SALT, &new_salt_b64)?;
-            set_config_impl(conn, KEY_VERIFY_TOKEN, &new_verify_token)?;
-            Ok(())
-        })();
-        match result {
-            Ok(_) => conn.execute_batch("COMMIT").map_err(|e| e.to_string())?,
-            Err(e) => {
-                let _ = conn.execute_batch("ROLLBACK");
-                return Err(e);
-            }
-        }
-    }
-
-    let mut guard = crypto.lock().map_err(|e| e.to_string())?;
-    guard.key = Some(new_key);
-    guard.salt = Some(B64.decode(&new_salt_b64).unwrap_or_default());
-    Ok(())
+    let guard = db.0.lock().map_err(|e| e.to_string())?;
+    change_encryption_password_impl(db_conn(&guard)?, &crypto, &old_password, &new_password)
 }

--- a/src-tauri/src/commands/file.rs
+++ b/src-tauri/src/commands/file.rs
@@ -1,6 +1,9 @@
+use crate::engine::validate_parent_dir_path;
+
 #[tauri::command]
 pub fn write_bytes_file(path: String, data: String) -> Result<(), String> {
     use base64::Engine;
+    validate_parent_dir_path(&path, "저장 위치의 디렉토리가 존재하지 않습니다.")?;
     let bytes = base64::engine::general_purpose::STANDARD
         .decode(&data)
         .map_err(|e| e.to_string())?;

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,6 +1,7 @@
 pub mod activity;
 pub mod area;
 pub mod config;
+pub mod crypto;
 pub mod file;
 pub mod project;
 pub mod record;
@@ -12,6 +13,7 @@ pub mod synonym;
 pub use activity::*;
 pub use area::*;
 pub use config::*;
+pub use crypto::*;
 pub use file::*;
 pub use project::*;
 pub use record::*;

--- a/src-tauri/src/commands/project.rs
+++ b/src-tauri/src/commands/project.rs
@@ -1,10 +1,11 @@
 use crate::engine::{validate_existing_path, validate_parent_dir_path};
-use crate::state::{clear_crypto_state, CryptoStateHandle, DbState};
+use crate::state::{clear_crypto_state, CryptoStateHandle, DbPathState, DbState};
 use tauri::State;
 
 pub(crate) fn new_project_impl(
     path: &str,
     state: &DbState,
+    db_path_state: &DbPathState,
     crypto: &CryptoStateHandle,
 ) -> Result<(), String> {
     validate_parent_dir_path(path, "디렉토리가 존재하지 않습니다.")?;
@@ -14,6 +15,7 @@ pub(crate) fn new_project_impl(
     }
     let conn = crate::db::create_new(p).map_err(|e| e.to_string())?;
     *state.0.lock().map_err(|e| e.to_string())? = Some(conn);
+    *db_path_state.0.lock().map_err(|e| e.to_string())? = Some(p.to_path_buf());
     clear_crypto_state(crypto)?;
     Ok(())
 }
@@ -21,6 +23,7 @@ pub(crate) fn new_project_impl(
 pub(crate) fn open_project_impl(
     path: &str,
     state: &DbState,
+    db_path_state: &DbPathState,
     crypto: &CryptoStateHandle,
 ) -> Result<(), String> {
     validate_existing_path(path, "파일이 존재하지 않거나 접근할 수 없습니다.")?;
@@ -35,6 +38,7 @@ pub(crate) fn open_project_impl(
 
     let conn = crate::db::open_existing(src).map_err(|e| e.to_string())?;
     *state.0.lock().map_err(|e| e.to_string())? = Some(conn);
+    *db_path_state.0.lock().map_err(|e| e.to_string())? = Some(src.to_path_buf());
     clear_crypto_state(crypto)?;
     Ok(())
 }
@@ -43,16 +47,18 @@ pub(crate) fn open_project_impl(
 pub fn new_project(
     path: String,
     state: State<DbState>,
+    db_path: State<DbPathState>,
     crypto: State<CryptoStateHandle>,
 ) -> Result<(), String> {
-    new_project_impl(&path, &state, &crypto)
+    new_project_impl(&path, &state, &db_path, &crypto)
 }
 
 #[tauri::command]
 pub fn open_project(
     path: String,
     state: State<DbState>,
+    db_path: State<DbPathState>,
     crypto: State<CryptoStateHandle>,
 ) -> Result<(), String> {
-    open_project_impl(&path, &state, &crypto)
+    open_project_impl(&path, &state, &db_path, &crypto)
 }

--- a/src-tauri/src/commands/project.rs
+++ b/src-tauri/src/commands/project.rs
@@ -1,3 +1,4 @@
+use crate::engine::{validate_existing_path, validate_parent_dir_path};
 use crate::state::{clear_crypto_state, CryptoStateHandle, DbState};
 use tauri::State;
 
@@ -6,6 +7,7 @@ pub(crate) fn new_project_impl(
     state: &DbState,
     crypto: &CryptoStateHandle,
 ) -> Result<(), String> {
+    validate_parent_dir_path(path, "디렉토리가 존재하지 않습니다.")?;
     let p = std::path::Path::new(&path);
     if p.exists() {
         return Err(format!("이미 파일이 존재합니다: {path}"));
@@ -21,6 +23,7 @@ pub(crate) fn open_project_impl(
     state: &DbState,
     crypto: &CryptoStateHandle,
 ) -> Result<(), String> {
+    validate_existing_path(path, "파일이 존재하지 않거나 접근할 수 없습니다.")?;
     let src = std::path::Path::new(&path);
 
     if let Some(parent) = src.parent() {

--- a/src-tauri/src/commands/project.rs
+++ b/src-tauri/src/commands/project.rs
@@ -14,7 +14,8 @@ pub(crate) fn new_project_impl(
         return Err(format!("이미 파일이 존재합니다: {path}"));
     }
     let conn = crate::db::create_new(p).map_err(|e| e.to_string())?;
-    *state.0.lock().map_err(|e| e.to_string())? = Some(conn);
+    let mut guard = state.0.lock().map_err(|e| e.to_string())?;
+    *guard = Some(conn);
     *db_path_state.0.lock().map_err(|e| e.to_string())? = Some(p.to_path_buf());
     clear_crypto_state(crypto)?;
     Ok(())
@@ -37,7 +38,8 @@ pub(crate) fn open_project_impl(
     }
 
     let conn = crate::db::open_existing(src).map_err(|e| e.to_string())?;
-    *state.0.lock().map_err(|e| e.to_string())? = Some(conn);
+    let mut guard = state.0.lock().map_err(|e| e.to_string())?;
+    *guard = Some(conn);
     *db_path_state.0.lock().map_err(|e| e.to_string())? = Some(src.to_path_buf());
     clear_crypto_state(crypto)?;
     Ok(())

--- a/src-tauri/src/commands/project.rs
+++ b/src-tauri/src/commands/project.rs
@@ -1,19 +1,26 @@
-use crate::state::DbState;
+use crate::state::{clear_crypto_state, CryptoStateHandle, DbState};
 use tauri::State;
 
-#[tauri::command]
-pub fn new_project(path: String, state: State<DbState>) -> Result<(), String> {
+pub(crate) fn new_project_impl(
+    path: &str,
+    state: &DbState,
+    crypto: &CryptoStateHandle,
+) -> Result<(), String> {
     let p = std::path::Path::new(&path);
     if p.exists() {
         return Err(format!("이미 파일이 존재합니다: {path}"));
     }
     let conn = crate::db::create_new(p).map_err(|e| e.to_string())?;
-    *state.0.lock().unwrap() = Some(conn);
+    *state.0.lock().map_err(|e| e.to_string())? = Some(conn);
+    clear_crypto_state(crypto)?;
     Ok(())
 }
 
-#[tauri::command]
-pub fn open_project(path: String, state: State<DbState>) -> Result<(), String> {
+pub(crate) fn open_project_impl(
+    path: &str,
+    state: &DbState,
+    crypto: &CryptoStateHandle,
+) -> Result<(), String> {
     let src = std::path::Path::new(&path);
 
     if let Some(parent) = src.parent() {
@@ -24,6 +31,25 @@ pub fn open_project(path: String, state: State<DbState>) -> Result<(), String> {
     }
 
     let conn = crate::db::open_existing(src).map_err(|e| e.to_string())?;
-    *state.0.lock().unwrap() = Some(conn);
+    *state.0.lock().map_err(|e| e.to_string())? = Some(conn);
+    clear_crypto_state(crypto)?;
     Ok(())
+}
+
+#[tauri::command]
+pub fn new_project(
+    path: String,
+    state: State<DbState>,
+    crypto: State<CryptoStateHandle>,
+) -> Result<(), String> {
+    new_project_impl(&path, &state, &crypto)
+}
+
+#[tauri::command]
+pub fn open_project(
+    path: String,
+    state: State<DbState>,
+    crypto: State<CryptoStateHandle>,
+) -> Result<(), String> {
+    open_project_impl(&path, &state, &crypto)
 }

--- a/src-tauri/src/commands/record.rs
+++ b/src-tauri/src/commands/record.rs
@@ -1,4 +1,5 @@
-use crate::state::DbState;
+use crate::crypto::{maybe_decrypt, maybe_encrypt};
+use crate::state::{CryptoStateHandle, DbState};
 use crate::types::{
     ActivityItem, AreaGridData, BulkImportResult, HistoryEntry, ImportRecordInput,
     PreviewImportItem, RecordCell, StudentItem,
@@ -7,7 +8,11 @@ use rusqlite::{Connection, OptionalExtension};
 use std::collections::HashMap;
 use tauri::State;
 
-pub fn get_area_grid_impl(conn: &Connection, area_id: i64) -> Result<AreaGridData, String> {
+pub fn get_area_grid_impl(
+    conn: &Connection,
+    area_id: i64,
+    key: Option<[u8; 32]>,
+) -> Result<AreaGridData, String> {
     let mut stmt = conn
         .prepare(
             "SELECT act.id, act.name
@@ -20,10 +25,7 @@ pub fn get_area_grid_impl(conn: &Connection, area_id: i64) -> Result<AreaGridDat
 
     let activities = stmt
         .query_map(rusqlite::params![area_id], |row| {
-            Ok(ActivityItem {
-                id: row.get(0)?,
-                name: row.get(1)?,
-            })
+            Ok(ActivityItem { id: row.get(0)?, name: row.get(1)? })
         })
         .map_err(|e| e.to_string())?
         .collect::<Result<Vec<_>, _>>()
@@ -39,19 +41,30 @@ pub fn get_area_grid_impl(conn: &Connection, area_id: i64) -> Result<AreaGridDat
         )
         .map_err(|e| e.to_string())?;
 
-    let students = stmt
+    let raw_students = stmt
         .query_map(rusqlite::params![area_id], |row| {
-            Ok(StudentItem {
-                id: row.get(0)?,
-                grade: row.get(1)?,
-                class_num: row.get(2)?,
-                number: row.get(3)?,
-                name: row.get(4)?,
-            })
+            Ok((
+                row.get::<_, i64>(0)?,
+                row.get::<_, i64>(1)?,
+                row.get::<_, i64>(2)?,
+                row.get::<_, i64>(3)?,
+                row.get::<_, String>(4)?,
+            ))
         })
         .map_err(|e| e.to_string())?
         .collect::<Result<Vec<_>, _>>()
         .map_err(|e| e.to_string())?;
+
+    let mut students = Vec::with_capacity(raw_students.len());
+    for (id, grade, class_num, number, name) in raw_students {
+        students.push(StudentItem {
+            id,
+            grade,
+            class_num,
+            number,
+            name: maybe_decrypt(name, key)?,
+        });
+    }
 
     let activity_ids: Vec<i64> = activities.iter().map(|a| a.id).collect();
     let student_ids: Vec<i64> = students.iter().map(|s| s.id).collect();
@@ -79,16 +92,22 @@ pub fn get_area_grid_impl(conn: &Connection, area_id: i64) -> Result<AreaGridDat
         );
         let params: Vec<i64> = activity_ids.iter().chain(student_ids.iter()).copied().collect();
         let mut stmt = conn.prepare(&sql).map_err(|e| e.to_string())?;
-        let rows = stmt.query_map(rusqlite::params_from_iter(params.iter()), |row| {
-            Ok(RecordCell {
-                activity_id: row.get(0)?,
-                student_id: row.get(1)?,
-                content: row.get(2)?,
+        let raw_rows = stmt
+            .query_map(rusqlite::params_from_iter(params.iter()), |row| {
+                Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?, row.get::<_, String>(2)?))
             })
-        })
-        .map_err(|e| e.to_string())?
-        .collect::<Result<Vec<_>, _>>()
-        .map_err(|e| e.to_string())?;
+            .map_err(|e| e.to_string())?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| e.to_string())?;
+
+        let mut rows = Vec::with_capacity(raw_rows.len());
+        for (activity_id, student_id, content) in raw_rows {
+            rows.push(RecordCell {
+                activity_id,
+                student_id,
+                content: maybe_decrypt(content, key)?,
+            });
+        }
         rows
     };
 
@@ -96,12 +115,15 @@ pub fn get_area_grid_impl(conn: &Connection, area_id: i64) -> Result<AreaGridDat
 }
 
 #[tauri::command]
-pub fn get_area_grid(area_id: i64, state: State<DbState>) -> Result<AreaGridData, String> {
+pub fn get_area_grid(
+    area_id: i64,
+    state: State<DbState>,
+    crypto: State<CryptoStateHandle>,
+) -> Result<AreaGridData, String> {
+    let key = crypto.lock().ok().and_then(|g| g.key);
     let guard = state.0.lock().unwrap();
-    let conn = guard
-        .as_ref()
-        .ok_or_else(|| "DB가 열려있지 않습니다.".to_string())?;
-    get_area_grid_impl(conn, area_id)
+    let conn = guard.as_ref().ok_or_else(|| "DB가 열려있지 않습니다.".to_string())?;
+    get_area_grid_impl(conn, area_id, key)
 }
 
 pub fn upsert_record_impl(
@@ -109,17 +131,18 @@ pub fn upsert_record_impl(
     activity_id: i64,
     student_id: i64,
     content: &str,
+    key: Option<[u8; 32]>,
 ) -> Result<(), String> {
+    let stored = maybe_encrypt(content, key)?;
     conn.execute(
         "INSERT INTO ActivityRecord (activity_id, student_id, content, updated_at)
          VALUES (?1, ?2, ?3, datetime('now'))
          ON CONFLICT(activity_id, student_id) DO UPDATE SET
            content = excluded.content,
            updated_at = excluded.updated_at",
-        rusqlite::params![activity_id, student_id, content],
+        rusqlite::params![activity_id, student_id, stored],
     )
     .map_err(|e| e.to_string())?;
-
     Ok(())
 }
 
@@ -129,12 +152,12 @@ pub fn upsert_record(
     student_id: i64,
     content: String,
     state: State<DbState>,
+    crypto: State<CryptoStateHandle>,
 ) -> Result<(), String> {
+    let key = crypto.lock().ok().and_then(|g| g.key);
     let guard = state.0.lock().unwrap();
-    let conn = guard
-        .as_ref()
-        .ok_or_else(|| "DB가 열려있지 않습니다.".to_string())?;
-    upsert_record_impl(conn, activity_id, student_id, &content)
+    let conn = guard.as_ref().ok_or_else(|| "DB가 열려있지 않습니다.".to_string())?;
+    upsert_record_impl(conn, activity_id, student_id, &content, key)
 }
 
 pub fn get_record_history_impl(
@@ -143,6 +166,7 @@ pub fn get_record_history_impl(
     student_id: i64,
     limit: i64,
     offset: i64,
+    key: Option<[u8; 32]>,
 ) -> Result<Vec<HistoryEntry>, String> {
     let mut stmt = conn
         .prepare(
@@ -155,19 +179,28 @@ pub fn get_record_history_impl(
         )
         .map_err(|e| e.to_string())?;
 
-    let entries = stmt
+    let raw = stmt
         .query_map(rusqlite::params![activity_id, student_id, limit, offset], |row| {
-            Ok(HistoryEntry {
-                id: row.get(0)?,
-                content: row.get(1)?,
-                changed_at: row.get(2)?,
-                note: row.get(3)?,
-            })
+            Ok((
+                row.get::<_, i64>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, Option<String>>(3)?,
+            ))
         })
         .map_err(|e| e.to_string())?
         .collect::<Result<Vec<_>, _>>()
         .map_err(|e| e.to_string())?;
 
+    let mut entries = Vec::with_capacity(raw.len());
+    for (id, content, changed_at, note) in raw {
+        entries.push(HistoryEntry {
+            id,
+            content: maybe_decrypt(content, key)?,
+            changed_at,
+            note,
+        });
+    }
     Ok(entries)
 }
 
@@ -178,12 +211,12 @@ pub fn get_record_history(
     limit: i64,
     offset: i64,
     state: State<DbState>,
+    crypto: State<CryptoStateHandle>,
 ) -> Result<Vec<HistoryEntry>, String> {
+    let key = crypto.lock().ok().and_then(|g| g.key);
     let guard = state.0.lock().unwrap();
-    let conn = guard
-        .as_ref()
-        .ok_or_else(|| "DB가 열려있지 않습니다.".to_string())?;
-    get_record_history_impl(conn, activity_id, student_id, limit, offset)
+    let conn = guard.as_ref().ok_or_else(|| "DB가 열려있지 않습니다.".to_string())?;
+    get_record_history_impl(conn, activity_id, student_id, limit, offset, key)
 }
 
 pub fn save_snapshot_internal(
@@ -192,19 +225,20 @@ pub fn save_snapshot_internal(
     student_id: i64,
     note: Option<&str>,
 ) -> Result<(), String> {
-    let inserted = conn.execute(
-        "INSERT INTO ActivityRecordHistory (activity_record_id, content, changed_at, note)
-         SELECT r.id, r.content, r.updated_at, ?3
-         FROM ActivityRecord r
-         WHERE r.activity_id = ?1 AND r.student_id = ?2
-           AND NOT EXISTS (
-               SELECT 1 FROM ActivityRecordHistory h
-               WHERE h.activity_record_id = r.id
-                 AND h.changed_at = r.updated_at
-           )",
-        rusqlite::params![activity_id, student_id, note],
-    )
-    .map_err(|e| e.to_string())?;
+    let inserted = conn
+        .execute(
+            "INSERT INTO ActivityRecordHistory (activity_record_id, content, changed_at, note)
+             SELECT r.id, r.content, r.updated_at, ?3
+             FROM ActivityRecord r
+             WHERE r.activity_id = ?1 AND r.student_id = ?2
+               AND NOT EXISTS (
+                   SELECT 1 FROM ActivityRecordHistory h
+                   WHERE h.activity_record_id = r.id
+                     AND h.changed_at = r.updated_at
+               )",
+            rusqlite::params![activity_id, student_id, note],
+        )
+        .map_err(|e| e.to_string())?;
 
     if inserted == 0 {
         conn.execute(
@@ -220,7 +254,6 @@ pub fn save_snapshot_internal(
         )
         .map_err(|e| e.to_string())?;
     }
-
     Ok(())
 }
 
@@ -232,16 +265,14 @@ pub fn save_history_snapshot(
     state: State<DbState>,
 ) -> Result<(), String> {
     let guard = state.0.lock().unwrap();
-    let conn = guard
-        .as_ref()
-        .ok_or_else(|| "DB가 열려있지 않습니다.".to_string())?;
-
+    let conn = guard.as_ref().ok_or_else(|| "DB가 열려있지 않습니다.".to_string())?;
     save_snapshot_internal(conn, activity_id, student_id, note.as_deref())
 }
 
 pub fn bulk_import_records_impl(
     conn: &Connection,
     records: &[ImportRecordInput],
+    key: Option<[u8; 32]>,
 ) -> Result<BulkImportResult, String> {
     let mut students_created: i64 = 0;
     let mut students_updated: i64 = 0;
@@ -249,9 +280,9 @@ pub fn bulk_import_records_impl(
     let mut student_cache: HashMap<(i64, i64, i64), i64> = HashMap::new();
 
     for r in records.iter() {
-        let key = (r.grade, r.class_num, r.number);
+        let cache_key = (r.grade, r.class_num, r.number);
 
-        if !student_cache.contains_key(&key) {
+        if !student_cache.contains_key(&cache_key) {
             let exists: bool = conn
                 .query_row(
                     "SELECT COUNT(*) FROM Student WHERE grade=?1 AND class_num=?2 AND number=?3",
@@ -264,17 +295,19 @@ pub fn bulk_import_records_impl(
             if exists {
                 if let Some(ref n) = r.name {
                     if !n.is_empty() {
-                        let existing_name: String = conn
+                        let existing_name_raw: String = conn
                             .query_row(
                                 "SELECT name FROM Student WHERE grade=?1 AND class_num=?2 AND number=?3",
                                 rusqlite::params![r.grade, r.class_num, r.number],
                                 |row| row.get(0),
                             )
                             .map_err(|e| e.to_string())?;
+                        let existing_name = maybe_decrypt(existing_name_raw, key)?;
                         if existing_name.trim().is_empty() {
+                            let stored_name = maybe_encrypt(n, key)?;
                             conn.execute(
                                 "UPDATE Student SET name = ?1 WHERE grade=?2 AND class_num=?3 AND number=?4",
-                                rusqlite::params![n, r.grade, r.class_num, r.number],
+                                rusqlite::params![stored_name, r.grade, r.class_num, r.number],
                             )
                             .map_err(|e| e.to_string())?;
                         }
@@ -283,9 +316,10 @@ pub fn bulk_import_records_impl(
                 students_updated += 1;
             } else {
                 let name = r.name.as_deref().unwrap_or("이름 없음");
+                let stored_name = maybe_encrypt(name, key)?;
                 conn.execute(
                     "INSERT INTO Student (grade, class_num, number, name) VALUES (?1, ?2, ?3, ?4)",
-                    rusqlite::params![r.grade, r.class_num, r.number, name],
+                    rusqlite::params![r.grade, r.class_num, r.number, stored_name],
                 )
                 .map_err(|e| e.to_string())?;
                 students_created += 1;
@@ -299,10 +333,11 @@ pub fn bulk_import_records_impl(
                 )
                 .map_err(|e| e.to_string())?;
 
-            student_cache.insert(key, student_id);
+            student_cache.insert(cache_key, student_id);
         }
 
-        let &student_id = student_cache.get(&key).ok_or_else(|| "캐시 오류".to_string())?;
+        let &student_id = student_cache.get(&cache_key).ok_or_else(|| "캐시 오류".to_string())?;
+        let stored_content = maybe_encrypt(&r.content, key)?;
 
         conn.execute(
             "INSERT INTO ActivityRecord (activity_id, student_id, content, updated_at)
@@ -310,7 +345,7 @@ pub fn bulk_import_records_impl(
              ON CONFLICT(activity_id, student_id) DO UPDATE SET
                content = excluded.content,
                updated_at = excluded.updated_at",
-            rusqlite::params![r.activity_id, student_id, r.content],
+            rusqlite::params![r.activity_id, student_id, stored_content],
         )
         .map_err(|e| e.to_string())?;
 
@@ -339,15 +374,14 @@ pub fn bulk_import_records_impl(
 pub fn bulk_import_records(
     records: Vec<ImportRecordInput>,
     state: State<DbState>,
+    crypto: State<CryptoStateHandle>,
 ) -> Result<BulkImportResult, String> {
+    let key = crypto.lock().ok().and_then(|g| g.key);
     let guard = state.0.lock().unwrap();
-    let conn = guard
-        .as_ref()
-        .ok_or_else(|| "DB가 열려있지 않습니다.".to_string())?;
+    let conn = guard.as_ref().ok_or_else(|| "DB가 열려있지 않습니다.".to_string())?;
 
     conn.execute_batch("BEGIN").map_err(|e| e.to_string())?;
-
-    match bulk_import_records_impl(conn, &records) {
+    match bulk_import_records_impl(conn, &records, key) {
         Ok(r) => {
             conn.execute_batch("COMMIT").map_err(|e| e.to_string())?;
             Ok(r)
@@ -362,6 +396,7 @@ pub fn bulk_import_records(
 pub fn preview_import_records_impl(
     conn: &Connection,
     records: &[ImportRecordInput],
+    key: Option<[u8; 32]>,
 ) -> Result<Vec<PreviewImportItem>, String> {
     let mut result = Vec::new();
     let mut student_cache: HashMap<(i64, i64, i64), Option<(i64, String)>> = HashMap::new();
@@ -384,8 +419,8 @@ pub fn preview_import_records_impl(
             name
         };
 
-        let key = (r.grade, r.class_num, r.number);
-        let student_info = if let Some(cached) = student_cache.get(&key) {
+        let cache_key = (r.grade, r.class_num, r.number);
+        let student_info = if let Some(cached) = student_cache.get(&cache_key) {
             cached.clone()
         } else {
             let info: Option<(i64, String)> = conn
@@ -396,7 +431,12 @@ pub fn preview_import_records_impl(
                 )
                 .optional()
                 .map_err(|e| e.to_string())?;
-            student_cache.insert(key, info.clone());
+            let info = info
+                .map(|(id, enc_name)| {
+                    maybe_decrypt(enc_name, key).map(|name| (id, name))
+                })
+                .transpose()?;
+            student_cache.insert(cache_key, info.clone());
             info
         };
 
@@ -410,7 +450,11 @@ pub fn preview_import_records_impl(
                     )
                     .optional()
                     .map_err(|e| e.to_string())?;
-                (name, content.unwrap_or_default())
+                let plain_content = match content {
+                    Some(c) => maybe_decrypt(c, key)?,
+                    None => String::new(),
+                };
+                (name, plain_content)
             }
             None => {
                 let name = r.name.as_deref().unwrap_or("이름 없음").to_string();
@@ -437,10 +481,10 @@ pub fn preview_import_records_impl(
 pub fn preview_import_records(
     records: Vec<ImportRecordInput>,
     state: State<DbState>,
+    crypto: State<CryptoStateHandle>,
 ) -> Result<Vec<PreviewImportItem>, String> {
+    let key = crypto.lock().ok().and_then(|g| g.key);
     let guard = state.0.lock().unwrap();
-    let conn = guard
-        .as_ref()
-        .ok_or_else(|| "DB가 열려있지 않습니다.".to_string())?;
-    preview_import_records_impl(conn, &records)
+    let conn = guard.as_ref().ok_or_else(|| "DB가 열려있지 않습니다.".to_string())?;
+    preview_import_records_impl(conn, &records, key)
 }

--- a/src-tauri/src/commands/record.rs
+++ b/src-tauri/src/commands/record.rs
@@ -1,3 +1,4 @@
+use crate::commands::crypto::resolve_data_key;
 use crate::crypto::{maybe_decrypt, maybe_encrypt};
 use crate::state::{CryptoStateHandle, DbState};
 use crate::types::{
@@ -25,7 +26,10 @@ pub fn get_area_grid_impl(
 
     let activities = stmt
         .query_map(rusqlite::params![area_id], |row| {
-            Ok(ActivityItem { id: row.get(0)?, name: row.get(1)? })
+            Ok(ActivityItem {
+                id: row.get(0)?,
+                name: row.get(1)?,
+            })
         })
         .map_err(|e| e.to_string())?
         .collect::<Result<Vec<_>, _>>()
@@ -90,11 +94,19 @@ pub fn get_area_grid_impl(
                AND student_id IN ({})",
             act_placeholders, stu_placeholders
         );
-        let params: Vec<i64> = activity_ids.iter().chain(student_ids.iter()).copied().collect();
+        let params: Vec<i64> = activity_ids
+            .iter()
+            .chain(student_ids.iter())
+            .copied()
+            .collect();
         let mut stmt = conn.prepare(&sql).map_err(|e| e.to_string())?;
         let raw_rows = stmt
             .query_map(rusqlite::params_from_iter(params.iter()), |row| {
-                Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?, row.get::<_, String>(2)?))
+                Ok((
+                    row.get::<_, i64>(0)?,
+                    row.get::<_, i64>(1)?,
+                    row.get::<_, String>(2)?,
+                ))
             })
             .map_err(|e| e.to_string())?
             .collect::<Result<Vec<_>, _>>()
@@ -111,7 +123,11 @@ pub fn get_area_grid_impl(
         rows
     };
 
-    Ok(AreaGridData { activities, students, records })
+    Ok(AreaGridData {
+        activities,
+        students,
+        records,
+    })
 }
 
 #[tauri::command]
@@ -120,9 +136,11 @@ pub fn get_area_grid(
     state: State<DbState>,
     crypto: State<CryptoStateHandle>,
 ) -> Result<AreaGridData, String> {
-    let key = crypto.lock().ok().and_then(|g| g.key);
     let guard = state.0.lock().unwrap();
-    let conn = guard.as_ref().ok_or_else(|| "DB가 열려있지 않습니다.".to_string())?;
+    let conn = guard
+        .as_ref()
+        .ok_or_else(|| "DB가 열려있지 않습니다.".to_string())?;
+    let key = resolve_data_key(conn, &crypto)?;
     get_area_grid_impl(conn, area_id, key)
 }
 
@@ -154,9 +172,11 @@ pub fn upsert_record(
     state: State<DbState>,
     crypto: State<CryptoStateHandle>,
 ) -> Result<(), String> {
-    let key = crypto.lock().ok().and_then(|g| g.key);
     let guard = state.0.lock().unwrap();
-    let conn = guard.as_ref().ok_or_else(|| "DB가 열려있지 않습니다.".to_string())?;
+    let conn = guard
+        .as_ref()
+        .ok_or_else(|| "DB가 열려있지 않습니다.".to_string())?;
+    let key = resolve_data_key(conn, &crypto)?;
     upsert_record_impl(conn, activity_id, student_id, &content, key)
 }
 
@@ -180,14 +200,17 @@ pub fn get_record_history_impl(
         .map_err(|e| e.to_string())?;
 
     let raw = stmt
-        .query_map(rusqlite::params![activity_id, student_id, limit, offset], |row| {
-            Ok((
-                row.get::<_, i64>(0)?,
-                row.get::<_, String>(1)?,
-                row.get::<_, String>(2)?,
-                row.get::<_, Option<String>>(3)?,
-            ))
-        })
+        .query_map(
+            rusqlite::params![activity_id, student_id, limit, offset],
+            |row| {
+                Ok((
+                    row.get::<_, i64>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                    row.get::<_, Option<String>>(3)?,
+                ))
+            },
+        )
         .map_err(|e| e.to_string())?
         .collect::<Result<Vec<_>, _>>()
         .map_err(|e| e.to_string())?;
@@ -213,9 +236,11 @@ pub fn get_record_history(
     state: State<DbState>,
     crypto: State<CryptoStateHandle>,
 ) -> Result<Vec<HistoryEntry>, String> {
-    let key = crypto.lock().ok().and_then(|g| g.key);
     let guard = state.0.lock().unwrap();
-    let conn = guard.as_ref().ok_or_else(|| "DB가 열려있지 않습니다.".to_string())?;
+    let conn = guard
+        .as_ref()
+        .ok_or_else(|| "DB가 열려있지 않습니다.".to_string())?;
+    let key = resolve_data_key(conn, &crypto)?;
     get_record_history_impl(conn, activity_id, student_id, limit, offset, key)
 }
 
@@ -265,7 +290,9 @@ pub fn save_history_snapshot(
     state: State<DbState>,
 ) -> Result<(), String> {
     let guard = state.0.lock().unwrap();
-    let conn = guard.as_ref().ok_or_else(|| "DB가 열려있지 않습니다.".to_string())?;
+    let conn = guard
+        .as_ref()
+        .ok_or_else(|| "DB가 열려있지 않습니다.".to_string())?;
     save_snapshot_internal(conn, activity_id, student_id, note.as_deref())
 }
 
@@ -336,7 +363,9 @@ pub fn bulk_import_records_impl(
             student_cache.insert(cache_key, student_id);
         }
 
-        let &student_id = student_cache.get(&cache_key).ok_or_else(|| "캐시 오류".to_string())?;
+        let &student_id = student_cache
+            .get(&cache_key)
+            .ok_or_else(|| "캐시 오류".to_string())?;
         let stored_content = maybe_encrypt(&r.content, key)?;
 
         conn.execute(
@@ -367,7 +396,11 @@ pub fn bulk_import_records_impl(
         records_saved += 1;
     }
 
-    Ok(BulkImportResult { students_created, students_updated, records_saved })
+    Ok(BulkImportResult {
+        students_created,
+        students_updated,
+        records_saved,
+    })
 }
 
 #[tauri::command]
@@ -376,9 +409,11 @@ pub fn bulk_import_records(
     state: State<DbState>,
     crypto: State<CryptoStateHandle>,
 ) -> Result<BulkImportResult, String> {
-    let key = crypto.lock().ok().and_then(|g| g.key);
     let guard = state.0.lock().unwrap();
-    let conn = guard.as_ref().ok_or_else(|| "DB가 열려있지 않습니다.".to_string())?;
+    let conn = guard
+        .as_ref()
+        .ok_or_else(|| "DB가 열려있지 않습니다.".to_string())?;
+    let key = resolve_data_key(conn, &crypto)?;
 
     conn.execute_batch("BEGIN").map_err(|e| e.to_string())?;
     match bulk_import_records_impl(conn, &records, key) {
@@ -432,9 +467,7 @@ pub fn preview_import_records_impl(
                 .optional()
                 .map_err(|e| e.to_string())?;
             let info = info
-                .map(|(id, enc_name)| {
-                    maybe_decrypt(enc_name, key).map(|name| (id, name))
-                })
+                .map(|(id, enc_name)| maybe_decrypt(enc_name, key).map(|name| (id, name)))
                 .transpose()?;
             student_cache.insert(cache_key, info.clone());
             info
@@ -483,8 +516,10 @@ pub fn preview_import_records(
     state: State<DbState>,
     crypto: State<CryptoStateHandle>,
 ) -> Result<Vec<PreviewImportItem>, String> {
-    let key = crypto.lock().ok().and_then(|g| g.key);
     let guard = state.0.lock().unwrap();
-    let conn = guard.as_ref().ok_or_else(|| "DB가 열려있지 않습니다.".to_string())?;
+    let conn = guard
+        .as_ref()
+        .ok_or_else(|| "DB가 열려있지 않습니다.".to_string())?;
+    let key = resolve_data_key(conn, &crypto)?;
     preview_import_records_impl(conn, &records, key)
 }

--- a/src-tauri/src/commands/replace.rs
+++ b/src-tauri/src/commands/replace.rs
@@ -1,5 +1,6 @@
+use crate::crypto::maybe_encrypt;
 use crate::engine::{apply_rules_cached, detect_conflicts, fetch_rules_from_db, get_records_for_scope};
-use crate::state::{DbState, ReplaceCacheState};
+use crate::state::{CryptoStateHandle, DbState, ReplaceCacheState};
 use crate::types::{ReplaceApplyResult, ReplacePreviewItem, ReplaceRule};
 use regex::Regex;
 use rusqlite::Connection;
@@ -240,7 +241,10 @@ pub fn preview_replace(
     area_ids: Vec<i64>,
     state: State<DbState>,
     cache: State<ReplaceCacheState>,
+    crypto: State<CryptoStateHandle>,
 ) -> Result<Vec<ReplacePreviewItem>, String> {
+    let key = crypto.lock().ok().and_then(|g| g.key);
+
     let (rules, records, act_names, stu_names) = {
         let guard = state.0.lock().unwrap();
         let conn = guard
@@ -248,7 +252,8 @@ pub fn preview_replace(
             .ok_or_else(|| "DB가 열려있지 않습니다.".to_string())?;
 
         let rules = fetch_rules_from_db(conn)?;
-        let records = get_records_for_scope(conn, &scope_type, &area_ids)?;
+        // get_records_for_scope now returns decrypted content
+        let records = get_records_for_scope(conn, &scope_type, &area_ids, key)?;
 
         let mut act_names: HashMap<i64, String> = HashMap::new();
         let mut stu_names: HashMap<i64, String> = HashMap::new();
@@ -261,14 +266,22 @@ pub fn preview_replace(
                 )
                 .unwrap_or_else(|_| format!("활동#{}", rec.activity_id))
             });
-            stu_names.entry(rec.student_id).or_insert_with(|| {
-                conn.query_row(
-                    "SELECT name FROM Student WHERE id=?1",
-                    rusqlite::params![rec.student_id],
-                    |r| r.get(0),
-                )
-                .unwrap_or_else(|_| format!("학생#{}", rec.student_id))
-            });
+            if !stu_names.contains_key(&rec.student_id) {
+                let raw_name: String = conn
+                    .query_row(
+                        "SELECT name FROM Student WHERE id=?1",
+                        rusqlite::params![rec.student_id],
+                        |r| r.get(0),
+                    )
+                    .unwrap_or_else(|_| format!("학생#{}", rec.student_id));
+                let name = if let Some(k) = key {
+                    crate::crypto::decrypt(&raw_name, &k)
+                        .unwrap_or_else(|_| raw_name)
+                } else {
+                    raw_name
+                };
+                stu_names.insert(rec.student_id, name);
+            }
         }
         (rules, records, act_names, stu_names)
     };
@@ -303,19 +316,24 @@ pub fn apply_replace(
     area_ids: Vec<i64>,
     state: State<DbState>,
     cache: State<ReplaceCacheState>,
+    crypto: State<CryptoStateHandle>,
 ) -> Result<ReplaceApplyResult, String> {
+    let key = crypto.lock().ok().and_then(|g| g.key);
+
     let (rules, records) = {
         let guard = state.0.lock().unwrap();
         let conn = guard
             .as_ref()
             .ok_or_else(|| "DB가 열려있지 않습니다.".to_string())?;
         let rules = fetch_rules_from_db(conn)?;
-        let records = get_records_for_scope(conn, &scope_type, &area_ids)?;
+        // get_records_for_scope returns decrypted content
+        let records = get_records_for_scope(conn, &scope_type, &area_ids, key)?;
         (rules, records)
     };
 
     let total_count = records.len() as i64;
 
+    // changes contains (activity_id, student_id, plain_new_content)
     let changes: Vec<(i64, i64, String)> = {
         let mut cache_guard = cache.lock().unwrap();
         records
@@ -343,14 +361,15 @@ pub fn apply_replace(
 
     conn.execute_batch("BEGIN").map_err(|e| e.to_string())?;
     let result: Result<(), String> = (|| {
-        for (activity_id, student_id, new_content) in &changes {
+        for (activity_id, student_id, plain_content) in &changes {
+            let stored = maybe_encrypt(plain_content, key)?;
             conn.execute(
                 "INSERT INTO ActivityRecord (activity_id, student_id, content, updated_at)
                  VALUES (?1, ?2, ?3, datetime('now'))
                  ON CONFLICT(activity_id, student_id) DO UPDATE SET
                    content = excluded.content,
                    updated_at = excluded.updated_at",
-                rusqlite::params![activity_id, student_id, new_content],
+                rusqlite::params![activity_id, student_id, stored],
             )
             .map_err(|e| e.to_string())?;
 

--- a/src-tauri/src/commands/replace.rs
+++ b/src-tauri/src/commands/replace.rs
@@ -3,7 +3,7 @@ use crate::crypto::{maybe_decrypt, maybe_encrypt};
 use crate::engine::{
     apply_rules_cached, detect_conflicts, fetch_rules_from_db, get_records_for_scope,
 };
-use crate::state::{CryptoStateHandle, DbState, ReplaceCacheState};
+use crate::state::{CryptoStateHandle, DbState, ReplaceCache, ReplaceCacheState};
 use crate::types::{ReplaceApplyResult, ReplacePreviewItem, ReplaceRule};
 use regex::Regex;
 use rusqlite::Connection;
@@ -247,61 +247,48 @@ pub fn seed_default_replace_rules(
     Ok(())
 }
 
-#[tauri::command]
-pub fn preview_replace(
-    scope_type: String,
-    area_ids: Vec<i64>,
-    state: State<DbState>,
-    cache: State<ReplaceCacheState>,
-    crypto: State<CryptoStateHandle>,
+pub fn preview_replace_impl(
+    conn: &Connection,
+    scope_type: &str,
+    area_ids: &[i64],
+    key: Option<[u8; 32]>,
+    cache: &mut ReplaceCache,
 ) -> Result<Vec<ReplacePreviewItem>, String> {
-    let (rules, records, act_names, stu_names) = {
-        let guard = state.0.lock().unwrap();
-        let conn = guard
-            .as_ref()
-            .ok_or_else(|| "DB가 열려있지 않습니다.".to_string())?;
-        let key = resolve_data_key(conn, &crypto)?;
+    let rules = fetch_rules_from_db(conn)?;
+    let records = get_records_for_scope(conn, scope_type, area_ids, key)?;
 
-        let rules = fetch_rules_from_db(conn)?;
-        let records = get_records_for_scope(conn, &scope_type, &area_ids, key)?;
-
-        let mut act_names: HashMap<i64, String> = HashMap::new();
-        let mut stu_names: HashMap<i64, String> = HashMap::new();
-        for rec in &records {
-            act_names.entry(rec.activity_id).or_insert_with(|| {
-                conn.query_row(
-                    "SELECT name FROM Activity WHERE id=?1",
-                    rusqlite::params![rec.activity_id],
+    let mut act_names: HashMap<i64, String> = HashMap::new();
+    let mut stu_names: HashMap<i64, String> = HashMap::new();
+    for rec in &records {
+        act_names.entry(rec.activity_id).or_insert_with(|| {
+            conn.query_row(
+                "SELECT name FROM Activity WHERE id=?1",
+                rusqlite::params![rec.activity_id],
+                |r| r.get(0),
+            )
+            .unwrap_or_else(|_| format!("활동#{}", rec.activity_id))
+        });
+        if !stu_names.contains_key(&rec.student_id) {
+            let raw_name: String = conn
+                .query_row(
+                    "SELECT name FROM Student WHERE id=?1",
+                    rusqlite::params![rec.student_id],
                     |r| r.get(0),
                 )
-                .unwrap_or_else(|_| format!("활동#{}", rec.activity_id))
-            });
-            if !stu_names.contains_key(&rec.student_id) {
-                let raw_name: String = conn
-                    .query_row(
-                        "SELECT name FROM Student WHERE id=?1",
-                        rusqlite::params![rec.student_id],
-                        |r| r.get(0),
-                    )
-                    .unwrap_or_else(|_| format!("학생#{}", rec.student_id));
-                let name = maybe_decrypt(raw_name, key)?;
-                stu_names.insert(rec.student_id, name);
-            }
+                .unwrap_or_else(|_| format!("학생#{}", rec.student_id));
+            let name = maybe_decrypt(raw_name, key)?;
+            stu_names.insert(rec.student_id, name);
         }
-        (rules, records, act_names, stu_names)
-    };
+    }
 
-    let mut cache_guard = cache.lock().unwrap();
     let mut items = Vec::new();
-
     for rec in &records {
-        let result = apply_rules_cached(&rec.content, &rules, &mut cache_guard);
+        let result = apply_rules_cached(&rec.content, &rules, cache);
         if result == rec.content {
             continue;
         }
         let activity_name = act_names.get(&rec.activity_id).cloned().unwrap_or_default();
         let student_name = stu_names.get(&rec.student_id).cloned().unwrap_or_default();
-
         items.push(ReplacePreviewItem {
             activity_id: rec.activity_id,
             student_id: rec.student_id,
@@ -311,59 +298,36 @@ pub fn preview_replace(
             result,
         });
     }
-
     Ok(items)
 }
 
-#[tauri::command]
-pub fn apply_replace(
-    scope_type: String,
-    area_ids: Vec<i64>,
-    state: State<DbState>,
-    cache: State<ReplaceCacheState>,
-    crypto: State<CryptoStateHandle>,
+pub fn apply_replace_impl(
+    conn: &Connection,
+    scope_type: &str,
+    area_ids: &[i64],
+    key: Option<[u8; 32]>,
+    cache: &mut ReplaceCache,
 ) -> Result<ReplaceApplyResult, String> {
-    let (key, rules, records) = {
-        let guard = state.0.lock().unwrap();
-        let conn = guard
-            .as_ref()
-            .ok_or_else(|| "DB가 열려있지 않습니다.".to_string())?;
-        let key = resolve_data_key(conn, &crypto)?;
-        let rules = fetch_rules_from_db(conn)?;
-        let records = get_records_for_scope(conn, &scope_type, &area_ids, key)?;
-        (key, rules, records)
-    };
-
+    let rules = fetch_rules_from_db(conn)?;
+    let records = get_records_for_scope(conn, scope_type, area_ids, key)?;
     let total_count = records.len() as i64;
 
-    // changes contains (activity_id, student_id, plain_new_content)
-    let changes: Vec<(i64, i64, String)> = {
-        let mut cache_guard = cache.lock().unwrap();
-        records
-            .iter()
-            .filter_map(|rec| {
-                let result = apply_rules_cached(&rec.content, &rules, &mut cache_guard);
-                if result != rec.content {
-                    Some((rec.activity_id, rec.student_id, result))
-                } else {
-                    None
-                }
-            })
-            .collect()
-    };
+    let changes: Vec<(i64, i64, String)> = records
+        .iter()
+        .filter_map(|rec| {
+            let result = apply_rules_cached(&rec.content, &rules, cache);
+            if result != rec.content {
+                Some((rec.activity_id, rec.student_id, result))
+            } else {
+                None
+            }
+        })
+        .collect();
 
     let changed_count = changes.len() as i64;
     if changes.is_empty() {
-        return Ok(ReplaceApplyResult {
-            changed_count: 0,
-            total_count,
-        });
+        return Ok(ReplaceApplyResult { changed_count: 0, total_count });
     }
-
-    let guard = state.0.lock().unwrap();
-    let conn = guard
-        .as_ref()
-        .ok_or_else(|| "DB가 열려있지 않습니다.".to_string())?;
 
     conn.execute_batch("BEGIN").map_err(|e| e.to_string())?;
     let result: Result<(), String> = (|| {
@@ -399,14 +363,45 @@ pub fn apply_replace(
     match result {
         Ok(_) => {
             conn.execute_batch("COMMIT").map_err(|e| e.to_string())?;
-            Ok(ReplaceApplyResult {
-                changed_count,
-                total_count,
-            })
+            Ok(ReplaceApplyResult { changed_count, total_count })
         }
         Err(e) => {
             let _ = conn.execute_batch("ROLLBACK");
             Err(e)
         }
     }
+}
+
+#[tauri::command]
+pub fn preview_replace(
+    scope_type: String,
+    area_ids: Vec<i64>,
+    state: State<DbState>,
+    cache: State<ReplaceCacheState>,
+    crypto: State<CryptoStateHandle>,
+) -> Result<Vec<ReplacePreviewItem>, String> {
+    let guard = state.0.lock().unwrap();
+    let conn = guard
+        .as_ref()
+        .ok_or_else(|| "DB가 열려있지 않습니다.".to_string())?;
+    let key = resolve_data_key(conn, &crypto)?;
+    let mut cache_guard = cache.lock().unwrap();
+    preview_replace_impl(conn, &scope_type, &area_ids, key, &mut cache_guard)
+}
+
+#[tauri::command]
+pub fn apply_replace(
+    scope_type: String,
+    area_ids: Vec<i64>,
+    state: State<DbState>,
+    cache: State<ReplaceCacheState>,
+    crypto: State<CryptoStateHandle>,
+) -> Result<ReplaceApplyResult, String> {
+    let guard = state.0.lock().unwrap();
+    let conn = guard
+        .as_ref()
+        .ok_or_else(|| "DB가 열려있지 않습니다.".to_string())?;
+    let key = resolve_data_key(conn, &crypto)?;
+    let mut cache_guard = cache.lock().unwrap();
+    apply_replace_impl(conn, &scope_type, &area_ids, key, &mut cache_guard)
 }

--- a/src-tauri/src/commands/replace.rs
+++ b/src-tauri/src/commands/replace.rs
@@ -1,5 +1,8 @@
-use crate::crypto::maybe_encrypt;
-use crate::engine::{apply_rules_cached, detect_conflicts, fetch_rules_from_db, get_records_for_scope};
+use crate::commands::crypto::resolve_data_key;
+use crate::crypto::{maybe_decrypt, maybe_encrypt};
+use crate::engine::{
+    apply_rules_cached, detect_conflicts, fetch_rules_from_db, get_records_for_scope,
+};
 use crate::state::{CryptoStateHandle, DbState, ReplaceCacheState};
 use crate::types::{ReplaceApplyResult, ReplacePreviewItem, ReplaceRule};
 use regex::Regex;
@@ -113,8 +116,11 @@ pub fn update_replace_rule_db(
 }
 
 pub fn delete_replace_rule_impl(conn: &Connection, id: i64) -> Result<(), String> {
-    conn.execute("DELETE FROM ReplaceRule WHERE id = ?1", rusqlite::params![id])
-        .map_err(|e| e.to_string())?;
+    conn.execute(
+        "DELETE FROM ReplaceRule WHERE id = ?1",
+        rusqlite::params![id],
+    )
+    .map_err(|e| e.to_string())?;
     Ok(())
 }
 
@@ -135,7 +141,11 @@ pub fn seed_default_replace_rules_impl(
         let old_text = rule["oldText"].as_str().ok_or("oldText 누락")?;
         let new_text = rule["newText"].as_str().ok_or("newText 누락")?;
         let priority = rule["priority"].as_i64().ok_or("priority 누락")?;
-        let is_regex: i64 = if rule["isRegex"].as_bool().unwrap_or(false) { 1 } else { 0 };
+        let is_regex: i64 = if rule["isRegex"].as_bool().unwrap_or(false) {
+            1
+        } else {
+            0
+        };
         conn.execute(
             "INSERT OR IGNORE INTO ReplaceRule (old_text, new_text, is_regex, priority) VALUES (?1, ?2, ?3, ?4)",
             rusqlite::params![old_text, new_text, is_regex, priority],
@@ -227,7 +237,9 @@ pub fn seed_default_replace_rules(
     cache: State<ReplaceCacheState>,
 ) -> Result<(), String> {
     let guard = state.0.lock().unwrap();
-    let conn = guard.as_ref().ok_or_else(|| "DB가 열려있지 않습니다.".to_string())?;
+    let conn = guard
+        .as_ref()
+        .ok_or_else(|| "DB가 열려있지 않습니다.".to_string())?;
 
     seed_default_replace_rules_impl(conn, &rules)?;
     drop(guard);
@@ -243,16 +255,14 @@ pub fn preview_replace(
     cache: State<ReplaceCacheState>,
     crypto: State<CryptoStateHandle>,
 ) -> Result<Vec<ReplacePreviewItem>, String> {
-    let key = crypto.lock().ok().and_then(|g| g.key);
-
     let (rules, records, act_names, stu_names) = {
         let guard = state.0.lock().unwrap();
         let conn = guard
             .as_ref()
             .ok_or_else(|| "DB가 열려있지 않습니다.".to_string())?;
+        let key = resolve_data_key(conn, &crypto)?;
 
         let rules = fetch_rules_from_db(conn)?;
-        // get_records_for_scope now returns decrypted content
         let records = get_records_for_scope(conn, &scope_type, &area_ids, key)?;
 
         let mut act_names: HashMap<i64, String> = HashMap::new();
@@ -274,12 +284,7 @@ pub fn preview_replace(
                         |r| r.get(0),
                     )
                     .unwrap_or_else(|_| format!("학생#{}", rec.student_id));
-                let name = if let Some(k) = key {
-                    crate::crypto::decrypt(&raw_name, &k)
-                        .unwrap_or_else(|_| raw_name)
-                } else {
-                    raw_name
-                };
+                let name = maybe_decrypt(raw_name, key)?;
                 stu_names.insert(rec.student_id, name);
             }
         }
@@ -318,17 +323,15 @@ pub fn apply_replace(
     cache: State<ReplaceCacheState>,
     crypto: State<CryptoStateHandle>,
 ) -> Result<ReplaceApplyResult, String> {
-    let key = crypto.lock().ok().and_then(|g| g.key);
-
-    let (rules, records) = {
+    let (key, rules, records) = {
         let guard = state.0.lock().unwrap();
         let conn = guard
             .as_ref()
             .ok_or_else(|| "DB가 열려있지 않습니다.".to_string())?;
+        let key = resolve_data_key(conn, &crypto)?;
         let rules = fetch_rules_from_db(conn)?;
-        // get_records_for_scope returns decrypted content
         let records = get_records_for_scope(conn, &scope_type, &area_ids, key)?;
-        (rules, records)
+        (key, rules, records)
     };
 
     let total_count = records.len() as i64;
@@ -351,7 +354,10 @@ pub fn apply_replace(
 
     let changed_count = changes.len() as i64;
     if changes.is_empty() {
-        return Ok(ReplaceApplyResult { changed_count: 0, total_count });
+        return Ok(ReplaceApplyResult {
+            changed_count: 0,
+            total_count,
+        });
     }
 
     let guard = state.0.lock().unwrap();
@@ -393,7 +399,10 @@ pub fn apply_replace(
     match result {
         Ok(_) => {
             conn.execute_batch("COMMIT").map_err(|e| e.to_string())?;
-            Ok(ReplaceApplyResult { changed_count, total_count })
+            Ok(ReplaceApplyResult {
+                changed_count,
+                total_count,
+            })
         }
         Err(e) => {
             let _ = conn.execute_batch("ROLLBACK");

--- a/src-tauri/src/commands/student.rs
+++ b/src-tauri/src/commands/student.rs
@@ -1,9 +1,13 @@
-use crate::state::{DbState, unique_err};
+use crate::crypto::{maybe_decrypt, maybe_encrypt};
+use crate::state::{unique_err, CryptoStateHandle, DbState};
 use crate::types::{BulkUpsertResult, StudentInput, StudentItem};
 use rusqlite::Connection;
 use tauri::State;
 
-pub fn get_students_impl(conn: &Connection) -> Result<Vec<StudentItem>, String> {
+pub fn get_students_impl(
+    conn: &Connection,
+    key: Option<[u8; 32]>,
+) -> Result<Vec<StudentItem>, String> {
     let mut stmt = conn
         .prepare(
             "SELECT id, grade, class_num, number, name
@@ -12,20 +16,30 @@ pub fn get_students_impl(conn: &Connection) -> Result<Vec<StudentItem>, String> 
         )
         .map_err(|e| e.to_string())?;
 
-    let students = stmt
+    let rows = stmt
         .query_map([], |row| {
-            Ok(StudentItem {
-                id: row.get(0)?,
-                grade: row.get(1)?,
-                class_num: row.get(2)?,
-                number: row.get(3)?,
-                name: row.get(4)?,
-            })
+            Ok((
+                row.get::<_, i64>(0)?,
+                row.get::<_, i64>(1)?,
+                row.get::<_, i64>(2)?,
+                row.get::<_, i64>(3)?,
+                row.get::<_, String>(4)?,
+            ))
         })
         .map_err(|e| e.to_string())?
         .collect::<Result<Vec<_>, _>>()
         .map_err(|e| e.to_string())?;
 
+    let mut students = Vec::with_capacity(rows.len());
+    for (id, grade, class_num, number, name) in rows {
+        students.push(StudentItem {
+            id,
+            grade,
+            class_num,
+            number,
+            name: maybe_decrypt(name, key)?,
+        });
+    }
     Ok(students)
 }
 
@@ -35,13 +49,16 @@ pub fn create_student_impl(
     class_num: i64,
     number: i64,
     name: &str,
+    key: Option<[u8; 32]>,
 ) -> Result<i64, String> {
+    let stored_name = maybe_encrypt(name, key)?;
     conn.execute(
         "INSERT INTO Student (grade, class_num, number, name) VALUES (?1, ?2, ?3, ?4)",
-        rusqlite::params![grade, class_num, number, name],
+        rusqlite::params![grade, class_num, number, stored_name],
     )
-    .map_err(|e| unique_err(&e, &format!("이미 같은 학번의 학생이 있습니다: {grade}학년 {class_num}반 {number}번")))?;
-
+    .map_err(|e| {
+        unique_err(&e, &format!("이미 같은 학번의 학생이 있습니다: {grade}학년 {class_num}반 {number}번"))
+    })?;
     Ok(conn.last_insert_rowid())
 }
 
@@ -52,36 +69,40 @@ pub fn update_student_impl(
     class_num: i64,
     number: i64,
     name: &str,
+    key: Option<[u8; 32]>,
 ) -> Result<(), String> {
+    let stored_name = maybe_encrypt(name, key)?;
     conn.execute(
         "UPDATE Student SET grade = ?1, class_num = ?2, number = ?3, name = ?4 WHERE id = ?5",
-        rusqlite::params![grade, class_num, number, name, id],
+        rusqlite::params![grade, class_num, number, stored_name, id],
     )
-    .map_err(|e| unique_err(&e, &format!("이미 같은 학번의 학생이 있습니다: {grade}학년 {class_num}반 {number}번")))?;
-
+    .map_err(|e| {
+        unique_err(&e, &format!("이미 같은 학번의 학생이 있습니다: {grade}학년 {class_num}반 {number}번"))
+    })?;
     Ok(())
 }
 
 pub fn delete_student_impl(conn: &Connection, id: i64) -> Result<(), String> {
     conn.execute("DELETE FROM Student WHERE id = ?1", rusqlite::params![id])
         .map_err(|e| e.to_string())?;
-
     Ok(())
 }
 
 pub fn bulk_upsert_students_impl(
     conn: &Connection,
     students: &[StudentInput],
+    key: Option<[u8; 32]>,
 ) -> Result<BulkUpsertResult, String> {
     conn.execute_batch("BEGIN").map_err(|e| e.to_string())?;
     let result = (|| -> Result<BulkUpsertResult, String> {
         let mut inserted: i64 = 0;
         let mut updated: i64 = 0;
         for s in students.iter() {
+            let stored_name = maybe_encrypt(&s.name, key)?;
             conn.execute(
                 "INSERT OR IGNORE INTO Student (grade, class_num, number, name)
                  VALUES (?1, ?2, ?3, ?4)",
-                rusqlite::params![s.grade, s.class_num, s.number, s.name],
+                rusqlite::params![s.grade, s.class_num, s.number, stored_name],
             )
             .map_err(|e| e.to_string())?;
 
@@ -90,7 +111,7 @@ pub fn bulk_upsert_students_impl(
             } else {
                 conn.execute(
                     "UPDATE Student SET name = ?1 WHERE grade=?2 AND class_num=?3 AND number=?4",
-                    rusqlite::params![s.name, s.grade, s.class_num, s.number],
+                    rusqlite::params![stored_name, s.grade, s.class_num, s.number],
                 )
                 .map_err(|e| e.to_string())?;
                 updated += 1;
@@ -188,13 +209,19 @@ pub fn set_area_activities_impl(
 
 // ── Tauri 커맨드 (얇은 래퍼) ─────────────────────────────────
 
+fn extract_key(crypto: &State<CryptoStateHandle>) -> Option<[u8; 32]> {
+    crypto.lock().ok().and_then(|g| g.key)
+}
+
 #[tauri::command]
-pub fn get_students(state: State<DbState>) -> Result<Vec<StudentItem>, String> {
+pub fn get_students(
+    state: State<DbState>,
+    crypto: State<CryptoStateHandle>,
+) -> Result<Vec<StudentItem>, String> {
+    let key = extract_key(&crypto);
     let guard = state.0.lock().unwrap();
-    let conn = guard
-        .as_ref()
-        .ok_or_else(|| "DB가 열려있지 않습니다.".to_string())?;
-    get_students_impl(conn)
+    let conn = guard.as_ref().ok_or_else(|| "DB가 열려있지 않습니다.".to_string())?;
+    get_students_impl(conn, key)
 }
 
 #[tauri::command]
@@ -204,12 +231,12 @@ pub fn create_student(
     number: i64,
     name: String,
     state: State<DbState>,
+    crypto: State<CryptoStateHandle>,
 ) -> Result<i64, String> {
+    let key = extract_key(&crypto);
     let guard = state.0.lock().unwrap();
-    let conn = guard
-        .as_ref()
-        .ok_or_else(|| "DB가 열려있지 않습니다.".to_string())?;
-    create_student_impl(conn, grade, class_num, number, &name)
+    let conn = guard.as_ref().ok_or_else(|| "DB가 열려있지 않습니다.".to_string())?;
+    create_student_impl(conn, grade, class_num, number, &name, key)
 }
 
 #[tauri::command]
@@ -220,20 +247,18 @@ pub fn update_student(
     number: i64,
     name: String,
     state: State<DbState>,
+    crypto: State<CryptoStateHandle>,
 ) -> Result<(), String> {
+    let key = extract_key(&crypto);
     let guard = state.0.lock().unwrap();
-    let conn = guard
-        .as_ref()
-        .ok_or_else(|| "DB가 열려있지 않습니다.".to_string())?;
-    update_student_impl(conn, id, grade, class_num, number, &name)
+    let conn = guard.as_ref().ok_or_else(|| "DB가 열려있지 않습니다.".to_string())?;
+    update_student_impl(conn, id, grade, class_num, number, &name, key)
 }
 
 #[tauri::command]
 pub fn delete_student(id: i64, state: State<DbState>) -> Result<(), String> {
     let guard = state.0.lock().unwrap();
-    let conn = guard
-        .as_ref()
-        .ok_or_else(|| "DB가 열려있지 않습니다.".to_string())?;
+    let conn = guard.as_ref().ok_or_else(|| "DB가 열려있지 않습니다.".to_string())?;
     delete_student_impl(conn, id)
 }
 
@@ -244,9 +269,7 @@ pub fn set_area_activities(
     state: State<DbState>,
 ) -> Result<(), String> {
     let guard = state.0.lock().unwrap();
-    let conn = guard
-        .as_ref()
-        .ok_or_else(|| "DB가 열려있지 않습니다.".to_string())?;
+    let conn = guard.as_ref().ok_or_else(|| "DB가 열려있지 않습니다.".to_string())?;
     set_area_activities_impl(conn, area_id, &activity_ids)
 }
 
@@ -254,20 +277,18 @@ pub fn set_area_activities(
 pub fn bulk_upsert_students(
     students: Vec<StudentInput>,
     state: State<DbState>,
+    crypto: State<CryptoStateHandle>,
 ) -> Result<BulkUpsertResult, String> {
+    let key = extract_key(&crypto);
     let guard = state.0.lock().unwrap();
-    let conn = guard
-        .as_ref()
-        .ok_or_else(|| "DB가 열려있지 않습니다.".to_string())?;
-    bulk_upsert_students_impl(conn, &students)
+    let conn = guard.as_ref().ok_or_else(|| "DB가 열려있지 않습니다.".to_string())?;
+    bulk_upsert_students_impl(conn, &students, key)
 }
 
 #[tauri::command]
 pub fn get_area_students(area_id: i64, state: State<DbState>) -> Result<Vec<i64>, String> {
     let guard = state.0.lock().unwrap();
-    let conn = guard
-        .as_ref()
-        .ok_or_else(|| "DB가 열려있지 않습니다.".to_string())?;
+    let conn = guard.as_ref().ok_or_else(|| "DB가 열려있지 않습니다.".to_string())?;
     get_area_students_impl(conn, area_id)
 }
 
@@ -278,8 +299,6 @@ pub fn set_area_students(
     state: State<DbState>,
 ) -> Result<(), String> {
     let guard = state.0.lock().unwrap();
-    let conn = guard
-        .as_ref()
-        .ok_or_else(|| "DB가 열려있지 않습니다.".to_string())?;
+    let conn = guard.as_ref().ok_or_else(|| "DB가 열려있지 않습니다.".to_string())?;
     set_area_students_impl(conn, area_id, &student_ids)
 }

--- a/src-tauri/src/commands/student.rs
+++ b/src-tauri/src/commands/student.rs
@@ -1,3 +1,4 @@
+use crate::commands::crypto::resolve_data_key;
 use crate::crypto::{maybe_decrypt, maybe_encrypt};
 use crate::state::{unique_err, CryptoStateHandle, DbState};
 use crate::types::{BulkUpsertResult, StudentInput, StudentItem};
@@ -57,7 +58,10 @@ pub fn create_student_impl(
         rusqlite::params![grade, class_num, number, stored_name],
     )
     .map_err(|e| {
-        unique_err(&e, &format!("이미 같은 학번의 학생이 있습니다: {grade}학년 {class_num}반 {number}번"))
+        unique_err(
+            &e,
+            &format!("이미 같은 학번의 학생이 있습니다: {grade}학년 {class_num}반 {number}번"),
+        )
     })?;
     Ok(conn.last_insert_rowid())
 }
@@ -77,7 +81,10 @@ pub fn update_student_impl(
         rusqlite::params![grade, class_num, number, stored_name, id],
     )
     .map_err(|e| {
-        unique_err(&e, &format!("이미 같은 학번의 학생이 있습니다: {grade}학년 {class_num}반 {number}번"))
+        unique_err(
+            &e,
+            &format!("이미 같은 학번의 학생이 있습니다: {grade}학년 {class_num}반 {number}번"),
+        )
     })?;
     Ok(())
 }
@@ -209,18 +216,16 @@ pub fn set_area_activities_impl(
 
 // ── Tauri 커맨드 (얇은 래퍼) ─────────────────────────────────
 
-fn extract_key(crypto: &State<CryptoStateHandle>) -> Option<[u8; 32]> {
-    crypto.lock().ok().and_then(|g| g.key)
-}
-
 #[tauri::command]
 pub fn get_students(
     state: State<DbState>,
     crypto: State<CryptoStateHandle>,
 ) -> Result<Vec<StudentItem>, String> {
-    let key = extract_key(&crypto);
     let guard = state.0.lock().unwrap();
-    let conn = guard.as_ref().ok_or_else(|| "DB가 열려있지 않습니다.".to_string())?;
+    let conn = guard
+        .as_ref()
+        .ok_or_else(|| "DB가 열려있지 않습니다.".to_string())?;
+    let key = resolve_data_key(conn, &crypto)?;
     get_students_impl(conn, key)
 }
 
@@ -233,9 +238,11 @@ pub fn create_student(
     state: State<DbState>,
     crypto: State<CryptoStateHandle>,
 ) -> Result<i64, String> {
-    let key = extract_key(&crypto);
     let guard = state.0.lock().unwrap();
-    let conn = guard.as_ref().ok_or_else(|| "DB가 열려있지 않습니다.".to_string())?;
+    let conn = guard
+        .as_ref()
+        .ok_or_else(|| "DB가 열려있지 않습니다.".to_string())?;
+    let key = resolve_data_key(conn, &crypto)?;
     create_student_impl(conn, grade, class_num, number, &name, key)
 }
 
@@ -249,16 +256,20 @@ pub fn update_student(
     state: State<DbState>,
     crypto: State<CryptoStateHandle>,
 ) -> Result<(), String> {
-    let key = extract_key(&crypto);
     let guard = state.0.lock().unwrap();
-    let conn = guard.as_ref().ok_or_else(|| "DB가 열려있지 않습니다.".to_string())?;
+    let conn = guard
+        .as_ref()
+        .ok_or_else(|| "DB가 열려있지 않습니다.".to_string())?;
+    let key = resolve_data_key(conn, &crypto)?;
     update_student_impl(conn, id, grade, class_num, number, &name, key)
 }
 
 #[tauri::command]
 pub fn delete_student(id: i64, state: State<DbState>) -> Result<(), String> {
     let guard = state.0.lock().unwrap();
-    let conn = guard.as_ref().ok_or_else(|| "DB가 열려있지 않습니다.".to_string())?;
+    let conn = guard
+        .as_ref()
+        .ok_or_else(|| "DB가 열려있지 않습니다.".to_string())?;
     delete_student_impl(conn, id)
 }
 
@@ -269,7 +280,9 @@ pub fn set_area_activities(
     state: State<DbState>,
 ) -> Result<(), String> {
     let guard = state.0.lock().unwrap();
-    let conn = guard.as_ref().ok_or_else(|| "DB가 열려있지 않습니다.".to_string())?;
+    let conn = guard
+        .as_ref()
+        .ok_or_else(|| "DB가 열려있지 않습니다.".to_string())?;
     set_area_activities_impl(conn, area_id, &activity_ids)
 }
 
@@ -279,16 +292,20 @@ pub fn bulk_upsert_students(
     state: State<DbState>,
     crypto: State<CryptoStateHandle>,
 ) -> Result<BulkUpsertResult, String> {
-    let key = extract_key(&crypto);
     let guard = state.0.lock().unwrap();
-    let conn = guard.as_ref().ok_or_else(|| "DB가 열려있지 않습니다.".to_string())?;
+    let conn = guard
+        .as_ref()
+        .ok_or_else(|| "DB가 열려있지 않습니다.".to_string())?;
+    let key = resolve_data_key(conn, &crypto)?;
     bulk_upsert_students_impl(conn, &students, key)
 }
 
 #[tauri::command]
 pub fn get_area_students(area_id: i64, state: State<DbState>) -> Result<Vec<i64>, String> {
     let guard = state.0.lock().unwrap();
-    let conn = guard.as_ref().ok_or_else(|| "DB가 열려있지 않습니다.".to_string())?;
+    let conn = guard
+        .as_ref()
+        .ok_or_else(|| "DB가 열려있지 않습니다.".to_string())?;
     get_area_students_impl(conn, area_id)
 }
 
@@ -299,6 +316,8 @@ pub fn set_area_students(
     state: State<DbState>,
 ) -> Result<(), String> {
     let guard = state.0.lock().unwrap();
-    let conn = guard.as_ref().ok_or_else(|| "DB가 열려있지 않습니다.".to_string())?;
+    let conn = guard
+        .as_ref()
+        .ok_or_else(|| "DB가 열려있지 않습니다.".to_string())?;
     set_area_students_impl(conn, area_id, &student_ids)
 }

--- a/src-tauri/src/commands/synonym.rs
+++ b/src-tauri/src/commands/synonym.rs
@@ -1,4 +1,5 @@
-use crate::state::{DbState, unique_err};
+use crate::crypto::maybe_decrypt;
+use crate::state::{unique_err, CryptoStateHandle, DbState};
 use crate::types::{InspectRecord, SeedGroupInput, SynonymGroupFull, SynonymWordItem};
 use rusqlite::Connection;
 use std::collections::HashMap;
@@ -110,21 +111,23 @@ pub fn get_all_records_for_inspect_impl(
     conn: &Connection,
     scope_type: &str,
     area_ids: Vec<i64>,
+    key: Option<[u8; 32]>,
 ) -> Result<Vec<InspectRecord>, String> {
-    let map_row = |row: &rusqlite::Row| {
-        Ok(InspectRecord {
-            id:            row.get(0)?,
-            activity_name: row.get(1)?,
-            student_name:  row.get(2)?,
-            area_name:     row.get(3)?,
-            grade:         row.get(4)?,
-            class_num:     row.get(5)?,
-            number:        row.get(6)?,
-            content:       row.get(7)?,
-        })
+    type RawRow = (i64, String, String, String, i64, i64, i64, String);
+    let map_row = |row: &rusqlite::Row| -> rusqlite::Result<RawRow> {
+        Ok((
+            row.get(0)?,
+            row.get(1)?,
+            row.get(2)?,
+            row.get(3)?,
+            row.get(4)?,
+            row.get(5)?,
+            row.get(6)?,
+            row.get(7)?,
+        ))
     };
 
-    match scope_type {
+    let raw: Vec<RawRow> = match scope_type {
         "all" => {
             let mut stmt = conn
                 .prepare(
@@ -140,8 +143,12 @@ pub fn get_all_records_for_inspect_impl(
                      ORDER BY a.id, act.id, s.grade, s.class_num, s.number",
                 )
                 .map_err(|e| e.to_string())?;
-            let rows = stmt.query_map([], map_row).map_err(|e| e.to_string())?;
-            rows.map(|r| r.map_err(|e| e.to_string())).collect()
+            let rows = stmt
+                .query_map([], map_row)
+                .map_err(|e| e.to_string())?
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|e| e.to_string())?;
+            rows
         }
         "areas" => {
             if area_ids.is_empty() {
@@ -164,11 +171,28 @@ pub fn get_all_records_for_inspect_impl(
             let mut stmt = conn.prepare(&sql).map_err(|e| e.to_string())?;
             let rows = stmt
                 .query_map(rusqlite::params_from_iter(area_ids.iter()), map_row)
+                .map_err(|e| e.to_string())?
+                .collect::<Result<Vec<_>, _>>()
                 .map_err(|e| e.to_string())?;
-            rows.map(|r| r.map_err(|e| e.to_string())).collect()
+            rows
         }
-        _ => Err(format!("알 수 없는 scope_type: {scope_type}")),
+        _ => return Err(format!("알 수 없는 scope_type: {scope_type}")),
+    };
+
+    let mut result = Vec::with_capacity(raw.len());
+    for (id, activity_name, student_name, area_name, grade, class_num, number, content) in raw {
+        result.push(InspectRecord {
+            id,
+            activity_name,
+            student_name: maybe_decrypt(student_name, key)?,
+            area_name,
+            grade,
+            class_num,
+            number,
+            content: maybe_decrypt(content, key)?,
+        });
     }
+    Ok(result)
 }
 
 // ── Tauri 명령어 래퍼 ──────────────────────────────────────────
@@ -220,8 +244,10 @@ pub fn get_all_records_for_inspect(
     scope_type: String,
     area_ids: Vec<i64>,
     state: State<DbState>,
+    crypto: State<CryptoStateHandle>,
 ) -> Result<Vec<InspectRecord>, String> {
+    let key = crypto.lock().ok().and_then(|g| g.key);
     let guard = state.0.lock().unwrap();
     let conn = guard.as_ref().ok_or_else(|| "DB가 열려있지 않습니다.".to_string())?;
-    get_all_records_for_inspect_impl(conn, &scope_type, area_ids)
+    get_all_records_for_inspect_impl(conn, &scope_type, area_ids, key)
 }

--- a/src-tauri/src/commands/synonym.rs
+++ b/src-tauri/src/commands/synonym.rs
@@ -1,3 +1,4 @@
+use crate::commands::crypto::resolve_data_key;
 use crate::crypto::maybe_decrypt;
 use crate::state::{unique_err, CryptoStateHandle, DbState};
 use crate::types::{InspectRecord, SeedGroupInput, SynonymGroupFull, SynonymWordItem};
@@ -36,12 +37,21 @@ pub fn get_synonym_groups_impl(conn: &Connection) -> Result<Vec<SynonymGroupFull
             i
         } else {
             let i = groups.len();
-            groups.push(SynonymGroupFull { id: gid, name: gname, created_at, items: vec![] });
+            groups.push(SynonymGroupFull {
+                id: gid,
+                name: gname,
+                created_at,
+                items: vec![],
+            });
             index_map.insert(gid, i);
             i
         };
         if let (Some(id), Some(w)) = (item_id, word) {
-            groups[idx].items.push(SynonymWordItem { id, group_id: gid, word: w });
+            groups[idx].items.push(SynonymWordItem {
+                id,
+                group_id: gid,
+                word: w,
+            });
         }
     }
 
@@ -75,7 +85,10 @@ pub fn delete_synonym_word_impl(conn: &Connection, id: i64) -> Result<(), String
     Ok(())
 }
 
-pub fn seed_default_synonyms_impl(conn: &Connection, groups: &[SeedGroupInput]) -> Result<(), String> {
+pub fn seed_default_synonyms_impl(
+    conn: &Connection,
+    groups: &[SeedGroupInput],
+) -> Result<(), String> {
     let count: i64 = conn
         .query_row("SELECT COUNT(*) FROM SynonymGroup", [], |r| r.get(0))
         .map_err(|e| e.to_string())?;
@@ -200,42 +213,57 @@ pub fn get_all_records_for_inspect_impl(
 #[tauri::command]
 pub fn get_synonym_groups(state: State<DbState>) -> Result<Vec<SynonymGroupFull>, String> {
     let guard = state.0.lock().unwrap();
-    let conn = guard.as_ref().ok_or_else(|| "DB가 열려있지 않습니다.".to_string())?;
+    let conn = guard
+        .as_ref()
+        .ok_or_else(|| "DB가 열려있지 않습니다.".to_string())?;
     get_synonym_groups_impl(conn)
 }
 
 #[tauri::command]
 pub fn create_synonym_group(name: String, state: State<DbState>) -> Result<i64, String> {
     let guard = state.0.lock().unwrap();
-    let conn = guard.as_ref().ok_or_else(|| "DB가 열려있지 않습니다.".to_string())?;
+    let conn = guard
+        .as_ref()
+        .ok_or_else(|| "DB가 열려있지 않습니다.".to_string())?;
     create_synonym_group_impl(conn, &name)
 }
 
 #[tauri::command]
 pub fn delete_synonym_group(id: i64, state: State<DbState>) -> Result<(), String> {
     let guard = state.0.lock().unwrap();
-    let conn = guard.as_ref().ok_or_else(|| "DB가 열려있지 않습니다.".to_string())?;
+    let conn = guard
+        .as_ref()
+        .ok_or_else(|| "DB가 열려있지 않습니다.".to_string())?;
     delete_synonym_group_impl(conn, id)
 }
 
 #[tauri::command]
 pub fn add_synonym_word(group_id: i64, word: String, state: State<DbState>) -> Result<i64, String> {
     let guard = state.0.lock().unwrap();
-    let conn = guard.as_ref().ok_or_else(|| "DB가 열려있지 않습니다.".to_string())?;
+    let conn = guard
+        .as_ref()
+        .ok_or_else(|| "DB가 열려있지 않습니다.".to_string())?;
     add_synonym_word_impl(conn, group_id, &word)
 }
 
 #[tauri::command]
 pub fn delete_synonym_word(id: i64, state: State<DbState>) -> Result<(), String> {
     let guard = state.0.lock().unwrap();
-    let conn = guard.as_ref().ok_or_else(|| "DB가 열려있지 않습니다.".to_string())?;
+    let conn = guard
+        .as_ref()
+        .ok_or_else(|| "DB가 열려있지 않습니다.".to_string())?;
     delete_synonym_word_impl(conn, id)
 }
 
 #[tauri::command]
-pub fn seed_default_synonyms(groups: Vec<SeedGroupInput>, state: State<DbState>) -> Result<(), String> {
+pub fn seed_default_synonyms(
+    groups: Vec<SeedGroupInput>,
+    state: State<DbState>,
+) -> Result<(), String> {
     let guard = state.0.lock().unwrap();
-    let conn = guard.as_ref().ok_or_else(|| "DB가 열려있지 않습니다.".to_string())?;
+    let conn = guard
+        .as_ref()
+        .ok_or_else(|| "DB가 열려있지 않습니다.".to_string())?;
     seed_default_synonyms_impl(conn, &groups)
 }
 
@@ -246,8 +274,10 @@ pub fn get_all_records_for_inspect(
     state: State<DbState>,
     crypto: State<CryptoStateHandle>,
 ) -> Result<Vec<InspectRecord>, String> {
-    let key = crypto.lock().ok().and_then(|g| g.key);
     let guard = state.0.lock().unwrap();
-    let conn = guard.as_ref().ok_or_else(|| "DB가 열려있지 않습니다.".to_string())?;
+    let conn = guard
+        .as_ref()
+        .ok_or_else(|| "DB가 열려있지 않습니다.".to_string())?;
+    let key = resolve_data_key(conn, &crypto)?;
     get_all_records_for_inspect_impl(conn, &scope_type, area_ids, key)
 }

--- a/src-tauri/src/crypto.rs
+++ b/src-tauri/src/crypto.rs
@@ -1,0 +1,73 @@
+use aes_gcm::{
+    aead::{Aead, AeadCore, KeyInit, OsRng},
+    Aes256Gcm, Key, Nonce,
+};
+use base64::{engine::general_purpose::STANDARD as B64, Engine};
+use pbkdf2::pbkdf2_hmac;
+use rand::RngCore;
+use sha2::Sha256;
+
+const PBKDF2_ITERATIONS: u32 = 100_000;
+
+pub fn generate_salt() -> [u8; 16] {
+    let mut salt = [0u8; 16];
+    rand::thread_rng().fill_bytes(&mut salt);
+    salt
+}
+
+pub fn derive_key(password: &str, salt: &[u8]) -> [u8; 32] {
+    let mut key = [0u8; 32];
+    pbkdf2_hmac::<Sha256>(password.as_bytes(), salt, PBKDF2_ITERATIONS, &mut key);
+    key
+}
+
+pub fn encrypt(plaintext: &str, key: &[u8]) -> Result<String, String> {
+    let cipher = Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(key));
+    let nonce = Aes256Gcm::generate_nonce(&mut OsRng);
+    let ciphertext = cipher
+        .encrypt(&nonce, plaintext.as_bytes())
+        .map_err(|e| format!("암호화 실패: {e}"))?;
+    let nonce_b64 = B64.encode(nonce.as_slice());
+    let cipher_b64 = B64.encode(&ciphertext);
+    Ok(format!("{nonce_b64}:{cipher_b64}"))
+}
+
+pub fn decrypt(value: &str, key: &[u8]) -> Result<String, String> {
+    let (nonce_b64, cipher_b64) = value
+        .split_once(':')
+        .ok_or_else(|| "잘못된 암호화 형식입니다.".to_string())?;
+    let nonce_bytes = B64
+        .decode(nonce_b64)
+        .map_err(|e| format!("nonce 디코딩 실패: {e}"))?;
+    let ciphertext = B64
+        .decode(cipher_b64)
+        .map_err(|e| format!("암호문 디코딩 실패: {e}"))?;
+    let cipher = Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(key));
+    let nonce = Nonce::from_slice(&nonce_bytes);
+    let plaintext = cipher
+        .decrypt(nonce, ciphertext.as_ref())
+        .map_err(|_| "복호화 실패: 비밀번호가 올바르지 않습니다.".to_string())?;
+    String::from_utf8(plaintext).map_err(|e| format!("UTF-8 변환 실패: {e}"))
+}
+
+/// 암호화 키가 있으면 복호화, 없거나 빈 문자열이면 그대로 반환
+pub fn maybe_decrypt(s: String, key: Option<[u8; 32]>) -> Result<String, String> {
+    if s.is_empty() {
+        return Ok(s);
+    }
+    match key {
+        Some(k) => decrypt(&s, &k),
+        None => Ok(s),
+    }
+}
+
+/// 암호화 키가 있으면 암호화, 없거나 빈 문자열이면 그대로 반환
+pub fn maybe_encrypt(s: &str, key: Option<[u8; 32]>) -> Result<String, String> {
+    if s.is_empty() {
+        return Ok(s.to_string());
+    }
+    match key {
+        Some(k) => encrypt(s, &k),
+        None => Ok(s.to_string()),
+    }
+}

--- a/src-tauri/src/crypto.rs
+++ b/src-tauri/src/crypto.rs
@@ -7,7 +7,16 @@ use pbkdf2::pbkdf2_hmac;
 use rand::RngCore;
 use sha2::Sha256;
 
+const AES_256_KEY_LEN: usize = 32;
+const AES_GCM_NONCE_LEN: usize = 12;
 const PBKDF2_ITERATIONS: u32 = 100_000;
+
+fn cipher_from_key(key: &[u8]) -> Result<Aes256Gcm, String> {
+    if key.len() != AES_256_KEY_LEN {
+        return Err(format!("잘못된 암호화 키 길이입니다: {} bytes", key.len()));
+    }
+    Ok(Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(key)))
+}
 
 pub fn generate_salt() -> [u8; 16] {
     let mut salt = [0u8; 16];
@@ -22,7 +31,7 @@ pub fn derive_key(password: &str, salt: &[u8]) -> [u8; 32] {
 }
 
 pub fn encrypt(plaintext: &str, key: &[u8]) -> Result<String, String> {
-    let cipher = Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(key));
+    let cipher = cipher_from_key(key)?;
     let nonce = Aes256Gcm::generate_nonce(&mut OsRng);
     let ciphertext = cipher
         .encrypt(&nonce, plaintext.as_bytes())
@@ -39,10 +48,16 @@ pub fn decrypt(value: &str, key: &[u8]) -> Result<String, String> {
     let nonce_bytes = B64
         .decode(nonce_b64)
         .map_err(|e| format!("nonce 디코딩 실패: {e}"))?;
+    if nonce_bytes.len() != AES_GCM_NONCE_LEN {
+        return Err(format!(
+            "잘못된 nonce 길이입니다: {} bytes",
+            nonce_bytes.len()
+        ));
+    }
     let ciphertext = B64
         .decode(cipher_b64)
         .map_err(|e| format!("암호문 디코딩 실패: {e}"))?;
-    let cipher = Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(key));
+    let cipher = cipher_from_key(key)?;
     let nonce = Nonce::from_slice(&nonce_bytes);
     let plaintext = cipher
         .decrypt(nonce, ciphertext.as_ref())

--- a/src-tauri/src/crypto.rs
+++ b/src-tauri/src/crypto.rs
@@ -9,7 +9,7 @@ use sha2::Sha256;
 
 const AES_256_KEY_LEN: usize = 32;
 const AES_GCM_NONCE_LEN: usize = 12;
-const PBKDF2_ITERATIONS: u32 = 100_000;
+const PBKDF2_ITERATIONS: u32 = 600_000;
 
 fn cipher_from_key(key: &[u8]) -> Result<Aes256Gcm, String> {
     if key.len() != AES_256_KEY_LEN {

--- a/src-tauri/src/engine.rs
+++ b/src-tauri/src/engine.rs
@@ -4,6 +4,7 @@ use std::collections::hash_map::DefaultHasher;
 use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
 
+use crate::crypto::maybe_decrypt;
 use crate::state::ReplaceCache;
 use crate::types::{RecordCell, ReplaceRule};
 
@@ -103,15 +104,8 @@ pub fn get_records_for_scope(
     conn: &Connection,
     scope_type: &str,
     area_ids: &[i64],
+    key: Option<[u8; 32]>,
 ) -> Result<Vec<RecordCell>, String> {
-    let map_row = |row: &rusqlite::Row| {
-        Ok(RecordCell {
-            activity_id: row.get(0)?,
-            student_id:  row.get(1)?,
-            content:     row.get(2)?,
-        })
-    };
-
     match scope_type {
         "all" => {
             let mut stmt = conn
@@ -120,11 +114,22 @@ pub fn get_records_for_scope(
                      FROM ActivityRecord WHERE content != ''",
                 )
                 .map_err(|e| e.to_string())?;
-            let result = stmt.query_map([], map_row)
+            let raw = stmt
+                .query_map([], |row| {
+                    Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?, row.get::<_, String>(2)?))
+                })
                 .map_err(|e| e.to_string())?
                 .collect::<Result<Vec<_>, _>>()
-                .map_err(|e| e.to_string());
-            result
+                .map_err(|e| e.to_string())?;
+            let mut result = Vec::with_capacity(raw.len());
+            for (activity_id, student_id, content) in raw {
+                result.push(RecordCell {
+                    activity_id,
+                    student_id,
+                    content: maybe_decrypt(content, key)?,
+                });
+            }
+            Ok(result)
         }
         "areas" => {
             if area_ids.is_empty() {
@@ -139,11 +144,22 @@ pub fn get_records_for_scope(
                  GROUP BY ar.activity_id, ar.student_id"
             );
             let mut stmt = conn.prepare(&sql).map_err(|e| e.to_string())?;
-            let result = stmt.query_map(rusqlite::params_from_iter(area_ids.iter()), map_row)
+            let raw = stmt
+                .query_map(rusqlite::params_from_iter(area_ids.iter()), |row| {
+                    Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?, row.get::<_, String>(2)?))
+                })
                 .map_err(|e| e.to_string())?
                 .collect::<Result<Vec<_>, _>>()
-                .map_err(|e| e.to_string());
-            result
+                .map_err(|e| e.to_string())?;
+            let mut result = Vec::with_capacity(raw.len());
+            for (activity_id, student_id, content) in raw {
+                result.push(RecordCell {
+                    activity_id,
+                    student_id,
+                    content: maybe_decrypt(content, key)?,
+                });
+            }
+            Ok(result)
         }
         _ => Err(format!("알 수 없는 scope_type: {scope_type}")),
     }

--- a/src-tauri/src/engine.rs
+++ b/src-tauri/src/engine.rs
@@ -3,10 +3,40 @@ use rusqlite::Connection;
 use std::collections::hash_map::DefaultHasher;
 use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
+use std::path::{Component, Path};
 
 use crate::crypto::maybe_decrypt;
 use crate::state::ReplaceCache;
 use crate::types::{RecordCell, ReplaceRule};
+
+fn validate_absolute_path_without_parent_dir(path: &str) -> Result<&Path, String> {
+    let p = Path::new(path);
+    if !p.is_absolute() {
+        return Err("절대 경로만 허용됩니다.".to_string());
+    }
+    for component in p.components() {
+        if component == Component::ParentDir {
+            return Err("경로에 '..'이 포함될 수 없습니다.".to_string());
+        }
+    }
+    Ok(p)
+}
+
+pub fn validate_existing_path(path: &str, not_found_message: &str) -> Result<(), String> {
+    let p = validate_absolute_path_without_parent_dir(path)?;
+    p.canonicalize()
+        .map_err(|_| not_found_message.to_string())?;
+    Ok(())
+}
+
+pub fn validate_parent_dir_path(path: &str, missing_parent_message: &str) -> Result<(), String> {
+    let p = validate_absolute_path_without_parent_dir(path)?;
+    p.parent()
+        .ok_or_else(|| "유효하지 않은 경로입니다.".to_string())?
+        .canonicalize()
+        .map_err(|_| missing_parent_message.to_string())?;
+    Ok(())
+}
 
 pub fn hash_content(content: &str) -> u64 {
     let mut hasher = DefaultHasher::new();

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2,6 +2,7 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 mod commands;
+mod crypto;
 mod db;
 mod engine;
 mod state;
@@ -10,7 +11,7 @@ mod types;
 mod tests;
 
 use commands::*;
-use state::{DbState, ReplaceCache};
+use state::{CryptoState, CryptoStateHandle, DbState, ReplaceCache};
 use std::collections::HashMap;
 use std::sync::Mutex;
 
@@ -23,6 +24,7 @@ fn main() {
             ruleset_version: 0,
             entries: HashMap::new(),
         }))
+        .manage(CryptoStateHandle::new(CryptoState { key: None, salt: None }))
         .invoke_handler(tauri::generate_handler![
             new_project,
             open_project,
@@ -69,6 +71,11 @@ fn main() {
             get_all_records_for_inspect,
             get_config,
             set_config,
+            get_encryption_status,
+            unlock_encryption,
+            enable_encryption,
+            disable_encryption,
+            change_encryption_password,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -11,7 +11,7 @@ mod types;
 mod tests;
 
 use commands::*;
-use state::{CryptoState, CryptoStateHandle, DbState, ReplaceCache};
+use state::{CryptoState, CryptoStateHandle, DbPathState, DbState, ReplaceCache};
 use std::collections::HashMap;
 use std::sync::Mutex;
 
@@ -20,6 +20,7 @@ fn main() {
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_dialog::init())
         .manage(DbState(Mutex::new(None)))
+        .manage(DbPathState(Mutex::new(None)))
         .manage(Mutex::new(ReplaceCache {
             ruleset_version: 0,
             entries: HashMap::new(),

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -1,9 +1,11 @@
 use rusqlite::Connection;
 use std::collections::HashMap;
 use std::sync::Mutex;
+use zeroize::{Zeroize, ZeroizeOnDrop};
 
 pub struct DbState(pub Mutex<Option<Connection>>);
 
+#[derive(Zeroize, ZeroizeOnDrop)]
 pub struct CryptoState {
     pub key: Option<[u8; 32]>,
     pub salt: Option<Vec<u8>>,
@@ -29,6 +31,8 @@ pub fn set_crypto_state(
 
 pub fn clear_crypto_state(crypto: &CryptoStateHandle) -> Result<(), String> {
     let mut guard = crypto.lock().map_err(|e| e.to_string())?;
+    if let Some(ref mut k) = guard.key { k.zeroize(); }
+    if let Some(ref mut s) = guard.salt { s.zeroize(); }
     guard.key = None;
     guard.salt = None;
     Ok(())

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -4,6 +4,13 @@ use std::sync::Mutex;
 
 pub struct DbState(pub Mutex<Option<Connection>>);
 
+pub struct CryptoState {
+    pub key: Option<[u8; 32]>,
+    pub salt: Option<Vec<u8>>,
+}
+
+pub type CryptoStateHandle = Mutex<CryptoState>;
+
 pub struct ReplaceCache {
     pub ruleset_version: u64,
     pub entries: HashMap<u64, (String, u64)>,

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -1,9 +1,11 @@
 use rusqlite::Connection;
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::sync::Mutex;
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
 pub struct DbState(pub Mutex<Option<Connection>>);
+pub struct DbPathState(pub Mutex<Option<PathBuf>>);
 
 #[derive(Zeroize, ZeroizeOnDrop)]
 pub struct CryptoState {

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -11,6 +11,29 @@ pub struct CryptoState {
 
 pub type CryptoStateHandle = Mutex<CryptoState>;
 
+pub fn current_crypto_key(crypto: &CryptoStateHandle) -> Result<Option<[u8; 32]>, String> {
+    let guard = crypto.lock().map_err(|e| e.to_string())?;
+    Ok(guard.key)
+}
+
+pub fn set_crypto_state(
+    crypto: &CryptoStateHandle,
+    key: [u8; 32],
+    salt: Vec<u8>,
+) -> Result<(), String> {
+    let mut guard = crypto.lock().map_err(|e| e.to_string())?;
+    guard.key = Some(key);
+    guard.salt = Some(salt);
+    Ok(())
+}
+
+pub fn clear_crypto_state(crypto: &CryptoStateHandle) -> Result<(), String> {
+    let mut guard = crypto.lock().map_err(|e| e.to_string())?;
+    guard.key = None;
+    guard.salt = None;
+    Ok(())
+}
+
 pub struct ReplaceCache {
     pub ruleset_version: u64,
     pub entries: HashMap<u64, (String, u64)>,

--- a/src-tauri/src/tests/crypto_cmd_tests.rs
+++ b/src-tauri/src/tests/crypto_cmd_tests.rs
@@ -1,4 +1,5 @@
 use super::{insert_activity, insert_area, insert_student, setup_temp_db_path_state, setup_test_db};
+use rusqlite::Connection;
 use crate::commands::config::set_config_impl;
 use crate::commands::crypto::{
     change_encryption_password_impl, disable_encryption_impl, enable_encryption_impl,
@@ -1019,4 +1020,135 @@ fn test_bulk_import_history_readable_with_key() {
         .unwrap();
     assert_ne!(raw_history, "발표 내용", "history DB에는 암호화된 값이 있어야 한다");
     assert!(raw_history.contains(':'));
+}
+
+// ── 파일 DB 재시작 시나리오 ───────────────────────────────────────────
+
+#[test]
+fn test_persist_and_reload_with_encryption() {
+    let (db_path_state, dir) = setup_temp_db_path_state();
+    let db_path = db_path_state.0.lock().unwrap().clone().unwrap();
+
+    // 1. 파일 DB 초기화 및 데이터 삽입
+    let conn = Connection::open(&db_path).unwrap();
+    conn.execute_batch("PRAGMA foreign_keys = ON;").unwrap();
+    conn.execute_batch(include_str!("../schema.sql")).unwrap();
+    let stu_id = insert_student(&conn, 1, 1, 1, "홍길동");
+    let area_id = insert_area(&conn, "독서", 500);
+    let act_id = insert_activity(&conn, "발표");
+    conn.execute(
+        "INSERT INTO AreaActivity (area_id, activity_id) VALUES (?1, ?2)",
+        rusqlite::params![area_id, act_id],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO AreaStudent (area_id, student_id) VALUES (?1, ?2)",
+        rusqlite::params![area_id, stu_id],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO ActivityRecord (activity_id, student_id, content) VALUES (?1, ?2, ?3)",
+        rusqlite::params![act_id, stu_id, "홍길동 발표 내용"],
+    )
+    .unwrap();
+
+    // 2. 암호화 활성화
+    let crypto = crypto_state(None);
+    enable_encryption_impl(&conn, &crypto, &db_path_state, "password").unwrap();
+
+    // 3. Connection 닫기 (재시작 시뮬레이션)
+    drop(conn);
+
+    // 4. 새 Connection으로 재오픈 + 잠금 상태 CryptoState
+    let conn2 = Connection::open(&db_path).unwrap();
+    conn2.execute_batch("PRAGMA foreign_keys = ON;").unwrap();
+    let crypto2 = crypto_state(None);
+
+    // 5. 구 비밀번호로 unlock → 성공
+    unlock_encryption_impl(&conn2, &crypto2, "password").unwrap();
+    let key = resolve_data_key(&conn2, &crypto2).unwrap().unwrap();
+
+    // 6. 데이터 복호화 확인
+    let grid = get_area_grid_impl(&conn2, area_id, Some(key)).unwrap();
+    let student = grid.students.iter().find(|s| s.id == stu_id).unwrap();
+    assert_eq!(student.name, "홍길동", "재시작 후 학생 이름이 올바르게 복호화되어야 한다");
+
+    let record = grid
+        .records
+        .iter()
+        .find(|r| r.student_id == stu_id && r.activity_id == act_id)
+        .unwrap();
+    assert_eq!(record.content, "홍길동 발표 내용", "재시작 후 기록 내용이 올바르게 복호화되어야 한다");
+
+    drop(conn2);
+    std::fs::remove_dir_all(dir).unwrap();
+}
+
+#[test]
+fn test_change_password_then_reload() {
+    let (db_path_state, dir) = setup_temp_db_path_state();
+    let db_path = db_path_state.0.lock().unwrap().clone().unwrap();
+
+    // 1. 파일 DB 초기화 및 암호화 활성화
+    let conn = Connection::open(&db_path).unwrap();
+    conn.execute_batch("PRAGMA foreign_keys = ON;").unwrap();
+    conn.execute_batch(include_str!("../schema.sql")).unwrap();
+    let stu_id = insert_student(&conn, 1, 1, 1, "김철수");
+    let area_id = insert_area(&conn, "수학", 500);
+    let act_id = insert_activity(&conn, "수행평가");
+    conn.execute(
+        "INSERT INTO AreaActivity (area_id, activity_id) VALUES (?1, ?2)",
+        rusqlite::params![area_id, act_id],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO AreaStudent (area_id, student_id) VALUES (?1, ?2)",
+        rusqlite::params![area_id, stu_id],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO ActivityRecord (activity_id, student_id, content) VALUES (?1, ?2, ?3)",
+        rusqlite::params![act_id, stu_id, "수행평가 우수"],
+    )
+    .unwrap();
+
+    let crypto = crypto_state(None);
+    enable_encryption_impl(&conn, &crypto, &db_path_state, "password").unwrap();
+
+    // 2. 비밀번호 변경
+    change_encryption_password_impl(&conn, &crypto, &db_path_state, "password", "new-password")
+        .unwrap();
+
+    // 3. Connection 닫기 (재시작 시뮬레이션)
+    drop(conn);
+
+    // 4. 새 Connection으로 재오픈
+    let conn2 = Connection::open(&db_path).unwrap();
+    conn2.execute_batch("PRAGMA foreign_keys = ON;").unwrap();
+    let crypto2 = crypto_state(None);
+
+    // 5. 구 비밀번호로 unlock → 실패
+    assert!(
+        unlock_encryption_impl(&conn2, &crypto2, "password").is_err(),
+        "변경 전 비밀번호로는 unlock이 실패해야 한다"
+    );
+
+    // 6. 새 비밀번호로 unlock → 성공
+    unlock_encryption_impl(&conn2, &crypto2, "new-password").unwrap();
+    let key = resolve_data_key(&conn2, &crypto2).unwrap().unwrap();
+
+    // 7. 데이터 복호화 확인
+    let grid = get_area_grid_impl(&conn2, area_id, Some(key)).unwrap();
+    let student = grid.students.iter().find(|s| s.id == stu_id).unwrap();
+    assert_eq!(student.name, "김철수", "비밀번호 변경 후 학생 이름이 올바르게 복호화되어야 한다");
+
+    let record = grid
+        .records
+        .iter()
+        .find(|r| r.student_id == stu_id && r.activity_id == act_id)
+        .unwrap();
+    assert_eq!(record.content, "수행평가 우수", "비밀번호 변경 후 기록 내용이 올바르게 복호화되어야 한다");
+
+    drop(conn2);
+    std::fs::remove_dir_all(dir).unwrap();
 }

--- a/src-tauri/src/tests/crypto_cmd_tests.rs
+++ b/src-tauri/src/tests/crypto_cmd_tests.rs
@@ -431,6 +431,27 @@ fn test_resolve_data_key_requires_unlock_when_enabled() {
 }
 
 #[test]
+fn test_change_password_creates_backup_file() {
+    let conn = setup_test_db();
+    let crypto = crypto_state(None);
+
+    let (db_path, tmp_dir) = setup_temp_db_path_state();
+    enable_encryption_impl(&conn, &crypto, &db_path, "password").unwrap();
+    change_encryption_password_impl(&conn, &crypto, &db_path, "password", "new-password").unwrap();
+
+    let backup_exists = std::fs::read_dir(&tmp_dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .any(|e| {
+            e.file_name()
+                .to_string_lossy()
+                .contains("-pre-reencrypt")
+        });
+    assert!(backup_exists, "비밀번호 변경 전 백업 파일이 생성되어야 한다");
+    std::fs::remove_dir_all(&tmp_dir).ok();
+}
+
+#[test]
 fn test_change_password_requires_new_password_afterward() {
     let conn = setup_test_db();
     let crypto = crypto_state(None);
@@ -438,7 +459,7 @@ fn test_change_password_requires_new_password_afterward() {
 
     let (db_path, tmp_dir) = setup_temp_db_path_state();
     enable_encryption_impl(&conn, &crypto, &db_path, "old-password").unwrap();
-    change_encryption_password_impl(&conn, &crypto, "old-password", "new-password").unwrap();
+    change_encryption_password_impl(&conn, &crypto, &db_path, "old-password", "new-password").unwrap();
     std::fs::remove_dir_all(&tmp_dir).ok();
 
     clear_crypto_state(&crypto).unwrap();

--- a/src-tauri/src/tests/crypto_cmd_tests.rs
+++ b/src-tauri/src/tests/crypto_cmd_tests.rs
@@ -5,15 +5,18 @@ use crate::commands::crypto::{
     get_encryption_status_impl, resolve_data_key, unlock_encryption_impl,
 };
 use crate::commands::record::{
-    get_area_grid_impl, get_record_history_impl, save_snapshot_internal, upsert_record_impl,
+    bulk_import_records_impl, get_area_grid_impl, get_record_history_impl,
+    preview_import_records_impl, save_snapshot_internal, upsert_record_impl,
 };
+use crate::commands::snapshot::{create_snapshot_impl, restore_snapshot_impl};
+use crate::commands::synonym::get_all_records_for_inspect_impl;
 use crate::commands::student::{
     bulk_upsert_students_impl, create_student_impl, get_students_impl, update_student_impl,
 };
 use crate::crypto::derive_key;
 use crate::engine::get_records_for_scope;
 use crate::state::{clear_crypto_state, CryptoState, CryptoStateHandle};
-use crate::types::StudentInput;
+use crate::types::{ImportRecordInput, StudentInput};
 
 fn test_key() -> [u8; 32] {
     derive_key("password", &[42u8; 16])
@@ -470,4 +473,213 @@ fn test_change_password_requires_new_password_afterward() {
     let students = get_students_impl(&conn, key).unwrap();
     assert_eq!(students[0].id, stu_id);
     assert_eq!(students[0].name, "홍길동");
+}
+
+// ── bulk_import_records: 암호화 경로 ─────────────────────────────
+
+fn make_import(
+    grade: i64,
+    class_num: i64,
+    number: i64,
+    name: Option<&str>,
+    activity_id: i64,
+    content: &str,
+) -> ImportRecordInput {
+    ImportRecordInput {
+        grade,
+        class_num,
+        number,
+        name: name.map(|s| s.to_string()),
+        activity_id,
+        content: content.to_string(),
+    }
+}
+
+#[test]
+fn test_bulk_import_records_with_key() {
+    let conn = setup_test_db();
+    let key = test_key();
+    let area_id = insert_area(&conn, "국어", 500);
+    let act_id = insert_activity(&conn, "발표");
+    conn.execute(
+        "INSERT INTO AreaActivity (area_id, activity_id) VALUES (?1, ?2)",
+        rusqlite::params![area_id, act_id],
+    )
+    .unwrap();
+
+    bulk_import_records_impl(
+        &conn,
+        &[make_import(1, 1, 1, Some("홍길동"), act_id, "발표 내용")],
+        Some(key),
+    )
+    .unwrap();
+
+    // DB에 이름과 content가 암호화된 채로 저장되어야 한다
+    let raw_name: String = conn
+        .query_row("SELECT name FROM Student WHERE grade=1", [], |r| r.get(0))
+        .unwrap();
+    assert_ne!(raw_name, "홍길동", "이름이 평문으로 저장되면 안 된다");
+    assert!(raw_name.contains(':'), "nonce:ciphertext 형식이어야 한다");
+
+    let raw_content: String = conn
+        .query_row(
+            "SELECT content FROM ActivityRecord WHERE activity_id=?1",
+            rusqlite::params![act_id],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_ne!(raw_content, "발표 내용", "content가 평문으로 저장되면 안 된다");
+    assert!(raw_content.contains(':'));
+
+    // Some(key)로 읽으면 복호화된 원문이 나와야 한다
+    conn.execute(
+        "INSERT INTO AreaStudent (area_id, student_id) VALUES (?1, (SELECT id FROM Student WHERE grade=1))",
+        rusqlite::params![area_id],
+    )
+    .unwrap();
+    let grid = get_area_grid_impl(&conn, area_id, Some(key)).unwrap();
+    assert_eq!(grid.students[0].name, "홍길동");
+    assert_eq!(grid.records[0].content, "발표 내용");
+}
+
+#[test]
+fn test_bulk_import_records_with_key_existing_empty_name() {
+    let conn = setup_test_db();
+    let key = test_key();
+    let act_id = insert_activity(&conn, "발표");
+
+    // 이름이 빈 학생을 암호화 상태로 생성 (maybe_encrypt("", key) == "")
+    create_student_impl(&conn, 1, 1, 1, "", Some(key)).unwrap();
+
+    // bulk_import로 이름 갱신 시도
+    bulk_import_records_impl(
+        &conn,
+        &[make_import(1, 1, 1, Some("새이름"), act_id, "내용")],
+        Some(key),
+    )
+    .unwrap();
+
+    // 이름이 갱신되고, 암호화된 채로 저장 후 복호화 시 새이름이어야 한다
+    let students = get_students_impl(&conn, Some(key)).unwrap();
+    assert_eq!(students[0].name, "새이름", "빈 이름은 갱신되어야 한다");
+
+    // DB에는 암호화된 값이 있어야 한다
+    let raw_name: String = conn
+        .query_row("SELECT name FROM Student WHERE grade=1", [], |r| r.get(0))
+        .unwrap();
+    assert_ne!(raw_name, "새이름");
+    assert!(raw_name.contains(':'));
+}
+
+// ── preview_import_records: 암호화 경로 ──────────────────────────
+
+#[test]
+fn test_preview_import_records_with_key() {
+    let conn = setup_test_db();
+    let key = test_key();
+    let act_id = insert_activity(&conn, "발표");
+    let stu_id = create_student_impl(&conn, 1, 1, 1, "홍길동", Some(key)).unwrap();
+    upsert_record_impl(&conn, act_id, stu_id, "기존 내용", Some(key)).unwrap();
+
+    let items = preview_import_records_impl(
+        &conn,
+        &[make_import(1, 1, 1, Some("홍길동"), act_id, "새 내용")],
+        Some(key),
+    )
+    .unwrap();
+
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0].student_name, "홍길동", "이름이 복호화되어야 한다");
+    assert_eq!(items[0].existing_content, "기존 내용", "기존 content가 복호화되어야 한다");
+    assert_eq!(items[0].new_content, "새 내용");
+}
+
+// ── get_all_records_for_inspect: 암호화 경로 ─────────────────────
+
+#[test]
+fn test_get_all_records_for_inspect_with_key_all_scope() {
+    let conn = setup_test_db();
+    let key = test_key();
+    let act_id = insert_activity(&conn, "발표");
+    let stu_id = create_student_impl(&conn, 1, 1, 1, "홍길동", Some(key)).unwrap();
+    upsert_record_impl(&conn, act_id, stu_id, "발표 평가 내용", Some(key)).unwrap();
+
+    // Some(key)로 조회 → 복호화된 원문
+    let records = get_all_records_for_inspect_impl(&conn, "all", vec![], Some(key)).unwrap();
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0].student_name, "홍길동");
+    assert_eq!(records[0].content, "발표 평가 내용");
+
+    // None으로 조회 → 암호화된 raw 값
+    let records_raw = get_all_records_for_inspect_impl(&conn, "all", vec![], None).unwrap();
+    assert_eq!(records_raw.len(), 1);
+    assert_ne!(records_raw[0].student_name, "홍길동", "키 없이 조회하면 암호화된 이름이어야 한다");
+    assert_ne!(records_raw[0].content, "발표 평가 내용", "키 없이 조회하면 암호화된 content여야 한다");
+}
+
+#[test]
+fn test_get_all_records_for_inspect_with_key_areas_scope() {
+    let conn = setup_test_db();
+    let key = test_key();
+    let area_id = insert_area(&conn, "국어", 500);
+    let act_id = insert_activity(&conn, "독서");
+    let stu_id = create_student_impl(&conn, 1, 1, 1, "김철수", Some(key)).unwrap();
+    conn.execute(
+        "INSERT INTO AreaActivity (area_id, activity_id) VALUES (?1, ?2)",
+        rusqlite::params![area_id, act_id],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO AreaStudent (area_id, student_id) VALUES (?1, ?2)",
+        rusqlite::params![area_id, stu_id],
+    )
+    .unwrap();
+    upsert_record_impl(&conn, act_id, stu_id, "독후감 내용", Some(key)).unwrap();
+
+    let records =
+        get_all_records_for_inspect_impl(&conn, "areas", vec![area_id], Some(key)).unwrap();
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0].student_name, "김철수");
+    assert_eq!(records[0].content, "독후감 내용");
+    assert_eq!(records[0].area_name, "국어");
+}
+
+// ── snapshot restore: 암호화 경로 ────────────────────────────────
+
+#[test]
+fn test_restore_snapshot_with_encryption() {
+    let conn = setup_test_db();
+    let key = test_key();
+    let area_id = insert_area(&conn, "국어", 500);
+    let act_id = insert_activity(&conn, "독서");
+    let stu_id = create_student_impl(&conn, 1, 1, 1, "홍길동", Some(key)).unwrap();
+    conn.execute(
+        "INSERT INTO AreaActivity (area_id, activity_id) VALUES (?1, ?2)",
+        rusqlite::params![area_id, act_id],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO AreaStudent (area_id, student_id) VALUES (?1, ?2)",
+        rusqlite::params![area_id, stu_id],
+    )
+    .unwrap();
+
+    // v1 내용 저장 후 스냅샷
+    upsert_record_impl(&conn, act_id, stu_id, "v1 내용", Some(key)).unwrap();
+    let snapshot = create_snapshot_impl(&conn, Some("v1 스냅샷".to_string())).unwrap();
+
+    // v2로 덮어쓰기
+    upsert_record_impl(&conn, act_id, stu_id, "v2 내용", Some(key)).unwrap();
+    let grid_v2 = get_area_grid_impl(&conn, area_id, Some(key)).unwrap();
+    assert_eq!(grid_v2.records[0].content, "v2 내용");
+
+    // 스냅샷 복원
+    restore_snapshot_impl(&conn, snapshot.id).unwrap();
+
+    // 복원 후 v1이 복호화되어 나와야 한다
+    let grid_restored = get_area_grid_impl(&conn, area_id, Some(key)).unwrap();
+    assert_eq!(
+        grid_restored.records[0].content, "v1 내용",
+        "스냅샷 복원 후 암호화된 v1 내용이 복호화되어야 한다"
+    );
 }

--- a/src-tauri/src/tests/crypto_cmd_tests.rs
+++ b/src-tauri/src/tests/crypto_cmd_tests.rs
@@ -1,0 +1,356 @@
+use crate::commands::record::{
+    get_area_grid_impl, get_record_history_impl, upsert_record_impl,
+};
+use crate::commands::student::{
+    bulk_upsert_students_impl, create_student_impl, get_students_impl, update_student_impl,
+};
+use crate::crypto::derive_key;
+use crate::engine::get_records_for_scope;
+use crate::types::StudentInput;
+use super::{insert_activity, insert_area, insert_student, setup_test_db};
+
+fn test_key() -> [u8; 32] {
+    derive_key("password", &[42u8; 16])
+}
+
+// ── 학생 이름 암호화 ──────────────────────────────────────────────
+
+#[test]
+fn test_create_student_with_key_stores_encrypted_name() {
+    let conn = setup_test_db();
+    let key = test_key();
+    create_student_impl(&conn, 1, 1, 1, "홍길동", Some(key)).unwrap();
+
+    // DB에는 암호화된 값이 저장되어야 한다
+    let raw_name: String = conn
+        .query_row("SELECT name FROM Student WHERE grade=1", [], |r| r.get(0))
+        .unwrap();
+    assert_ne!(raw_name, "홍길동", "DB에 평문이 저장되면 안 된다");
+    assert!(raw_name.contains(':'), "nonce:ciphertext 형식이어야 한다");
+}
+
+#[test]
+fn test_get_students_with_key_decrypts_name() {
+    let conn = setup_test_db();
+    let key = test_key();
+    create_student_impl(&conn, 1, 1, 1, "홍길동", Some(key)).unwrap();
+
+    let students = get_students_impl(&conn, Some(key)).unwrap();
+    assert_eq!(students[0].name, "홍길동");
+}
+
+#[test]
+fn test_get_students_without_key_returns_encrypted_value() {
+    let conn = setup_test_db();
+    let key = test_key();
+    create_student_impl(&conn, 1, 1, 1, "홍길동", Some(key)).unwrap();
+
+    // 키 없이 조회하면 암호화된 raw 값이 그대로 나온다
+    let students = get_students_impl(&conn, None).unwrap();
+    assert_ne!(students[0].name, "홍길동");
+}
+
+#[test]
+fn test_update_student_with_key_stores_and_reads_correctly() {
+    let conn = setup_test_db();
+    let key = test_key();
+    let id = create_student_impl(&conn, 1, 1, 1, "원래이름", Some(key)).unwrap();
+    update_student_impl(&conn, id, 1, 1, 1, "변경이름", Some(key)).unwrap();
+
+    let students = get_students_impl(&conn, Some(key)).unwrap();
+    assert_eq!(students[0].name, "변경이름");
+}
+
+#[test]
+fn test_get_students_sorted_order_preserved_with_encryption() {
+    let conn = setup_test_db();
+    let key = test_key();
+    create_student_impl(&conn, 2, 1, 1, "세번째", Some(key)).unwrap();
+    create_student_impl(&conn, 1, 2, 1, "두번째", Some(key)).unwrap();
+    create_student_impl(&conn, 1, 1, 1, "첫번째", Some(key)).unwrap();
+
+    let students = get_students_impl(&conn, Some(key)).unwrap();
+    assert_eq!(students[0].name, "첫번째");
+    assert_eq!(students[1].name, "두번째");
+    assert_eq!(students[2].name, "세번째");
+}
+
+#[test]
+fn test_bulk_upsert_students_with_key() {
+    let conn = setup_test_db();
+    let key = test_key();
+    let inputs = vec![
+        StudentInput { grade: 1, class_num: 1, number: 1, name: "가".to_string() },
+        StudentInput { grade: 1, class_num: 1, number: 2, name: "나".to_string() },
+    ];
+    let result = bulk_upsert_students_impl(&conn, &inputs, Some(key)).unwrap();
+    assert_eq!(result.inserted, 2);
+
+    let students = get_students_impl(&conn, Some(key)).unwrap();
+    let names: Vec<&str> = students.iter().map(|s| s.name.as_str()).collect();
+    assert!(names.contains(&"가"));
+    assert!(names.contains(&"나"));
+}
+
+#[test]
+fn test_bulk_upsert_students_update_overwrites_with_encryption() {
+    let conn = setup_test_db();
+    let key = test_key();
+    // 1차 삽입
+    bulk_upsert_students_impl(
+        &conn,
+        &[StudentInput { grade: 1, class_num: 1, number: 1, name: "원래".to_string() }],
+        Some(key),
+    ).unwrap();
+    // 2차 갱신
+    bulk_upsert_students_impl(
+        &conn,
+        &[StudentInput { grade: 1, class_num: 1, number: 1, name: "변경".to_string() }],
+        Some(key),
+    ).unwrap();
+
+    let students = get_students_impl(&conn, Some(key)).unwrap();
+    assert_eq!(students[0].name, "변경");
+}
+
+// ── 기록 content 암호화 ───────────────────────────────────────────
+
+#[test]
+fn test_upsert_record_with_key_stores_encrypted_content() {
+    let conn = setup_test_db();
+    let key = test_key();
+    let act_id = insert_activity(&conn, "발표");
+    let stu_id = insert_student(&conn, 1, 1, 1, "홍길동");
+
+    upsert_record_impl(&conn, act_id, stu_id, "리더십이 뛰어난 학생입니다.", Some(key)).unwrap();
+
+    let raw: String = conn
+        .query_row(
+            "SELECT content FROM ActivityRecord WHERE activity_id=?1 AND student_id=?2",
+            rusqlite::params![act_id, stu_id],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_ne!(raw, "리더십이 뛰어난 학생입니다.", "DB에 평문이 저장되면 안 된다");
+    assert!(raw.contains(':'), "nonce:ciphertext 형식이어야 한다");
+}
+
+#[test]
+fn test_upsert_record_empty_content_not_encrypted() {
+    let conn = setup_test_db();
+    let key = test_key();
+    let act_id = insert_activity(&conn, "발표");
+    let stu_id = insert_student(&conn, 1, 1, 1, "홍길동");
+
+    upsert_record_impl(&conn, act_id, stu_id, "", Some(key)).unwrap();
+
+    let raw: String = conn
+        .query_row(
+            "SELECT content FROM ActivityRecord WHERE activity_id=?1 AND student_id=?2",
+            rusqlite::params![act_id, stu_id],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(raw, "", "빈 문자열은 암호화하지 않아야 한다");
+}
+
+#[test]
+fn test_get_area_grid_with_key_decrypts_content_and_name() {
+    let conn = setup_test_db();
+    let key = test_key();
+    let area_id = insert_area(&conn, "국어", 500);
+    let act_id = insert_activity(&conn, "독서");
+    let stu_id = create_student_impl(&conn, 1, 1, 1, "김철수", Some(key)).unwrap();
+
+    conn.execute(
+        "INSERT INTO AreaActivity (area_id, activity_id) VALUES (?1, ?2)",
+        rusqlite::params![area_id, act_id],
+    ).unwrap();
+    conn.execute(
+        "INSERT INTO AreaStudent (area_id, student_id) VALUES (?1, ?2)",
+        rusqlite::params![area_id, stu_id],
+    ).unwrap();
+    upsert_record_impl(&conn, act_id, stu_id, "독후감 내용", Some(key)).unwrap();
+
+    let grid = get_area_grid_impl(&conn, area_id, Some(key)).unwrap();
+    assert_eq!(grid.students[0].name, "김철수");
+    assert_eq!(grid.records[0].content, "독후감 내용");
+}
+
+#[test]
+fn test_get_record_history_with_key_decrypts_content() {
+    let conn = setup_test_db();
+    let key = test_key();
+    let act_id = insert_activity(&conn, "발표");
+    let stu_id = insert_student(&conn, 1, 1, 1, "홍길동");
+
+    upsert_record_impl(&conn, act_id, stu_id, "발표 내용", Some(key)).unwrap();
+
+    // 히스토리에 암호화된 content를 직접 삽입
+    let encrypted_content: String = conn
+        .query_row(
+            "SELECT content FROM ActivityRecord WHERE activity_id=?1 AND student_id=?2",
+            rusqlite::params![act_id, stu_id],
+            |r| r.get(0),
+        )
+        .unwrap();
+    conn.execute(
+        "INSERT INTO ActivityRecordHistory (activity_record_id, content, changed_at, note)
+         SELECT id, content, '2024-01-01 10:00:00', NULL FROM ActivityRecord
+         WHERE activity_id=?1 AND student_id=?2",
+        rusqlite::params![act_id, stu_id],
+    ).unwrap();
+
+    let history = get_record_history_impl(&conn, act_id, stu_id, 10, 0, Some(key)).unwrap();
+    assert_eq!(history.len(), 1);
+    assert_eq!(history[0].content, "발표 내용", "복호화된 히스토리 content여야 한다");
+    // DB에는 여전히 암호화 값이 저장되어 있어야 한다
+    assert!(encrypted_content.contains(':'));
+}
+
+// ── engine: get_records_for_scope ─────────────────────────────────
+
+#[test]
+fn test_get_records_for_scope_all_with_key_decrypts() {
+    let conn = setup_test_db();
+    let key = test_key();
+    let act_id = insert_activity(&conn, "활동");
+    let stu_id = insert_student(&conn, 1, 1, 1, "학생");
+    upsert_record_impl(&conn, act_id, stu_id, "기록 내용", Some(key)).unwrap();
+
+    let records = get_records_for_scope(&conn, "all", &[], Some(key)).unwrap();
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0].content, "기록 내용");
+}
+
+#[test]
+fn test_get_records_for_scope_all_without_key_returns_encrypted() {
+    let conn = setup_test_db();
+    let key = test_key();
+    let act_id = insert_activity(&conn, "활동");
+    let stu_id = insert_student(&conn, 1, 1, 1, "학생");
+    upsert_record_impl(&conn, act_id, stu_id, "기록 내용", Some(key)).unwrap();
+
+    let records = get_records_for_scope(&conn, "all", &[], None).unwrap();
+    assert_eq!(records.len(), 1);
+    assert_ne!(records[0].content, "기록 내용", "키 없이 조회하면 암호화된 값이 나와야 한다");
+}
+
+#[test]
+fn test_get_records_for_scope_areas_with_key_decrypts() {
+    let conn = setup_test_db();
+    let key = test_key();
+    let area_id = insert_area(&conn, "국어", 500);
+    let act_id = insert_activity(&conn, "활동");
+    let stu_id = insert_student(&conn, 1, 1, 1, "학생");
+    conn.execute(
+        "INSERT INTO AreaActivity (area_id, activity_id) VALUES (?1, ?2)",
+        rusqlite::params![area_id, act_id],
+    ).unwrap();
+    conn.execute(
+        "INSERT INTO AreaStudent (area_id, student_id) VALUES (?1, ?2)",
+        rusqlite::params![area_id, stu_id],
+    ).unwrap();
+    upsert_record_impl(&conn, act_id, stu_id, "영역별 내용", Some(key)).unwrap();
+
+    let records = get_records_for_scope(&conn, "areas", &[area_id], Some(key)).unwrap();
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0].content, "영역별 내용");
+}
+
+// ── 암호화 없을 때 기존 동작 보존 ─────────────────────────────────
+
+#[test]
+fn test_create_get_student_without_encryption_unchanged() {
+    let conn = setup_test_db();
+    create_student_impl(&conn, 1, 1, 1, "홍길동", None).unwrap();
+    let students = get_students_impl(&conn, None).unwrap();
+    assert_eq!(students[0].name, "홍길동");
+}
+
+#[test]
+fn test_upsert_get_record_without_encryption_unchanged() {
+    let conn = setup_test_db();
+    let act_id = insert_activity(&conn, "발표");
+    let stu_id = insert_student(&conn, 1, 1, 1, "홍길동");
+    upsert_record_impl(&conn, act_id, stu_id, "발표 내용", None).unwrap();
+
+    let content: String = conn
+        .query_row(
+            "SELECT content FROM ActivityRecord WHERE activity_id=?1",
+            rusqlite::params![act_id],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(content, "발표 내용");
+}
+
+// ── 기존 평문 데이터 → 키 적용 시 에러 (일관성 검증) ───────────────
+
+#[test]
+fn test_decrypt_plaintext_with_key_returns_error() {
+    let conn = setup_test_db();
+    let key = test_key();
+    // 평문으로 저장된 학생 이름을 key로 복호화하려 하면 에러여야 한다
+    insert_student(&conn, 1, 1, 1, "평문이름");
+
+    let result = get_students_impl(&conn, Some(key));
+    // "잘못된 암호화 형식" 또는 "복호화 실패" 에러
+    assert!(result.is_err(), "평문을 키로 복호화하면 에러여야 한다");
+}
+
+// ── enable_all_data / disable_all_data 흐름 통합 검증 ──────────────
+
+#[test]
+fn test_encrypt_then_decrypt_all_data_restores_plaintext() {
+    use crate::crypto::{decrypt, encrypt};
+
+    let conn = setup_test_db();
+    let key = test_key();
+
+    // 1. 평문으로 데이터 삽입
+    let act_id = insert_activity(&conn, "활동");
+    let stu_id = insert_student(&conn, 1, 1, 1, "홍길동");
+    conn.execute(
+        "INSERT INTO ActivityRecord (activity_id, student_id, content) VALUES (?1, ?2, ?3)",
+        rusqlite::params![act_id, stu_id, "활동 기록"],
+    ).unwrap();
+
+    // 2. 수동으로 각 테이블 암호화 (enable_encryption의 핵심 로직)
+    let raw_name: String = conn
+        .query_row("SELECT name FROM Student WHERE id=?1", rusqlite::params![stu_id], |r| r.get(0))
+        .unwrap();
+    conn.execute(
+        "UPDATE Student SET name=?1 WHERE id=?2",
+        rusqlite::params![encrypt(&raw_name, &key).unwrap(), stu_id],
+    ).unwrap();
+
+    let raw_content: String = conn
+        .query_row(
+            "SELECT content FROM ActivityRecord WHERE activity_id=?1 AND student_id=?2",
+            rusqlite::params![act_id, stu_id],
+            |r| r.get(0),
+        )
+        .unwrap();
+    conn.execute(
+        "UPDATE ActivityRecord SET content=?1 WHERE activity_id=?2 AND student_id=?3",
+        rusqlite::params![encrypt(&raw_content, &key).unwrap(), act_id, stu_id],
+    ).unwrap();
+
+    // 3. 암호화 상태에서 _impl 으로 읽기
+    let students = get_students_impl(&conn, Some(key)).unwrap();
+    assert_eq!(students[0].name, "홍길동");
+
+    // 4. 수동으로 복호화 (disable_encryption의 핵심 로직)
+    let enc_name: String = conn
+        .query_row("SELECT name FROM Student WHERE id=?1", rusqlite::params![stu_id], |r| r.get(0))
+        .unwrap();
+    conn.execute(
+        "UPDATE Student SET name=?1 WHERE id=?2",
+        rusqlite::params![decrypt(&enc_name, &key).unwrap(), stu_id],
+    ).unwrap();
+
+    // 5. 복호화 후 None 키로 읽으면 평문이 나와야 한다
+    let students = get_students_impl(&conn, None).unwrap();
+    assert_eq!(students[0].name, "홍길동");
+}

--- a/src-tauri/src/tests/crypto_cmd_tests.rs
+++ b/src-tauri/src/tests/crypto_cmd_tests.rs
@@ -1152,3 +1152,75 @@ fn test_change_password_then_reload() {
     drop(conn2);
     std::fs::remove_dir_all(dir).unwrap();
 }
+
+// ── 레거시 스냅샷 × 암호화 활성화 경계 테스트 ────────────────────────
+//
+// 실제 발생 가능한 시나리오:
+//   기존 버전(암호화 없음)에서 스냅샷을 생성한 뒤,
+//   신규 버전에서 암호화를 활성화하고 스냅샷을 복원하는 경우.
+//
+// 동작 근거:
+//   enable_encryption_impl이 ActivityRecordHistory.content도 암호화하므로,
+//   복원 시 history에서 읽히는 값은 암호화된 상태이고 get_area_grid_impl이
+//   키로 복호화하여 원래 평문을 반환한다.
+
+#[test]
+fn test_restore_plaintext_snapshot_after_encryption_enabled() {
+    let conn = setup_test_db();
+    let crypto = crypto_state(None);
+    let (db_path, tmp_dir) = setup_temp_db_path_state();
+
+    let area_id = insert_area(&conn, "국어", 500);
+    let act_id = insert_activity(&conn, "발표");
+    let stu_id = insert_student(&conn, 1, 1, 1, "홍길동");
+    conn.execute(
+        "INSERT INTO AreaActivity (area_id, activity_id) VALUES (?1, ?2)",
+        rusqlite::params![area_id, act_id],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO AreaStudent (area_id, student_id) VALUES (?1, ?2)",
+        rusqlite::params![area_id, stu_id],
+    )
+    .unwrap();
+
+    // 1. 암호화 없이 v1 기록 및 스냅샷 생성 (레거시 동작)
+    upsert_record_impl(&conn, act_id, stu_id, "v1 내용", None).unwrap();
+    let snapshot = create_snapshot_impl(&conn, Some("v1 스냅샷".to_string())).unwrap();
+
+    // 2. 암호화 없이 v2로 덮어쓰기
+    upsert_record_impl(&conn, act_id, stu_id, "v2 내용", None).unwrap();
+
+    // 3. 암호화 활성화
+    //    → ActivityRecord.content AND ActivityRecordHistory.content 모두 암호화됨
+    enable_encryption_impl(&conn, &crypto, &db_path, "password").unwrap();
+    let key = resolve_data_key(&conn, &crypto).unwrap().unwrap();
+
+    // 4. 암호화 상태에서 현재 값이 v2인지 확인
+    let grid = get_area_grid_impl(&conn, area_id, Some(key)).unwrap();
+    assert_eq!(grid.records[0].content, "v2 내용", "암호화 활성화 후 현재 값은 v2여야 한다");
+
+    // 5. 암호화 전 생성된 스냅샷으로 복원
+    //    restore_snapshot_impl은 암호화된 history에서 읽어 ActivityRecord에 복사
+    restore_snapshot_impl(&conn, snapshot.id).unwrap();
+
+    // 6. 복원 후 v1이 복호화되어 나와야 한다
+    let grid_restored = get_area_grid_impl(&conn, area_id, Some(key)).unwrap();
+    assert_eq!(
+        grid_restored.records[0].content, "v1 내용",
+        "암호화 전 스냅샷 복원 후에도 올바른 v1 평문이 반환되어야 한다"
+    );
+
+    // 7. DB에 암호화된 값이 저장되어 있어야 한다 (복원 후에도 암호화 유지)
+    let raw: String = conn
+        .query_row(
+            "SELECT content FROM ActivityRecord WHERE activity_id=?1 AND student_id=?2",
+            rusqlite::params![act_id, stu_id],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_ne!(raw, "v1 내용", "복원 후에도 DB에는 암호화된 값이 저장되어야 한다");
+    assert!(raw.contains(':'), "복원된 값이 nonce:ciphertext 형식이어야 한다");
+
+    std::fs::remove_dir_all(&tmp_dir).ok();
+}

--- a/src-tauri/src/tests/crypto_cmd_tests.rs
+++ b/src-tauri/src/tests/crypto_cmd_tests.rs
@@ -1,4 +1,4 @@
-use super::{insert_activity, insert_area, insert_student, setup_test_db};
+use super::{insert_activity, insert_area, insert_student, setup_temp_db_path_state, setup_test_db};
 use crate::commands::config::set_config_impl;
 use crate::commands::crypto::{
     change_encryption_password_impl, disable_encryption_impl, enable_encryption_impl,
@@ -365,7 +365,8 @@ fn test_encrypt_then_decrypt_all_data_restores_plaintext() {
     upsert_record_impl(&conn, act_id, stu_id, "활동 기록", None).unwrap();
     save_snapshot_internal(&conn, act_id, stu_id, Some("before encryption")).unwrap();
 
-    enable_encryption_impl(&conn, &crypto, "password").unwrap();
+    let (db_path, tmp_dir) = setup_temp_db_path_state();
+    enable_encryption_impl(&conn, &crypto, &db_path, "password").unwrap();
     let status = get_encryption_status_impl(&conn, &crypto).unwrap();
     assert!(status.enabled);
     assert!(status.unlocked);
@@ -401,7 +402,8 @@ fn test_encrypt_then_decrypt_all_data_restores_plaintext() {
     assert_eq!(students[0].name, "홍길동");
 
     // 3. 복호화 후 None 키로 읽으면 평문이 나와야 한다
-    disable_encryption_impl(&conn, &crypto).unwrap();
+    disable_encryption_impl(&conn, &crypto, &db_path).unwrap();
+    std::fs::remove_dir_all(&tmp_dir).ok();
     let status = get_encryption_status_impl(&conn, &crypto).unwrap();
     assert!(!status.enabled);
     assert!(!status.unlocked);
@@ -434,8 +436,10 @@ fn test_change_password_requires_new_password_afterward() {
     let crypto = crypto_state(None);
     let stu_id = insert_student(&conn, 1, 1, 1, "홍길동");
 
-    enable_encryption_impl(&conn, &crypto, "old-password").unwrap();
+    let (db_path, tmp_dir) = setup_temp_db_path_state();
+    enable_encryption_impl(&conn, &crypto, &db_path, "old-password").unwrap();
     change_encryption_password_impl(&conn, &crypto, "old-password", "new-password").unwrap();
+    std::fs::remove_dir_all(&tmp_dir).ok();
 
     clear_crypto_state(&crypto).unwrap();
     assert!(unlock_encryption_impl(&conn, &crypto, "old-password").is_err());

--- a/src-tauri/src/tests/crypto_cmd_tests.rs
+++ b/src-tauri/src/tests/crypto_cmd_tests.rs
@@ -1,16 +1,26 @@
+use super::{insert_activity, insert_area, insert_student, setup_test_db};
+use crate::commands::config::set_config_impl;
+use crate::commands::crypto::{
+    change_encryption_password_impl, disable_encryption_impl, enable_encryption_impl,
+    get_encryption_status_impl, resolve_data_key, unlock_encryption_impl,
+};
 use crate::commands::record::{
-    get_area_grid_impl, get_record_history_impl, upsert_record_impl,
+    get_area_grid_impl, get_record_history_impl, save_snapshot_internal, upsert_record_impl,
 };
 use crate::commands::student::{
     bulk_upsert_students_impl, create_student_impl, get_students_impl, update_student_impl,
 };
 use crate::crypto::derive_key;
 use crate::engine::get_records_for_scope;
+use crate::state::{clear_crypto_state, CryptoState, CryptoStateHandle};
 use crate::types::StudentInput;
-use super::{insert_activity, insert_area, insert_student, setup_test_db};
 
 fn test_key() -> [u8; 32] {
     derive_key("password", &[42u8; 16])
+}
+
+fn crypto_state(key: Option<[u8; 32]>) -> CryptoStateHandle {
+    std::sync::Mutex::new(CryptoState { key, salt: None })
 }
 
 // ── 학생 이름 암호화 ──────────────────────────────────────────────
@@ -80,8 +90,18 @@ fn test_bulk_upsert_students_with_key() {
     let conn = setup_test_db();
     let key = test_key();
     let inputs = vec![
-        StudentInput { grade: 1, class_num: 1, number: 1, name: "가".to_string() },
-        StudentInput { grade: 1, class_num: 1, number: 2, name: "나".to_string() },
+        StudentInput {
+            grade: 1,
+            class_num: 1,
+            number: 1,
+            name: "가".to_string(),
+        },
+        StudentInput {
+            grade: 1,
+            class_num: 1,
+            number: 2,
+            name: "나".to_string(),
+        },
     ];
     let result = bulk_upsert_students_impl(&conn, &inputs, Some(key)).unwrap();
     assert_eq!(result.inserted, 2);
@@ -99,15 +119,27 @@ fn test_bulk_upsert_students_update_overwrites_with_encryption() {
     // 1차 삽입
     bulk_upsert_students_impl(
         &conn,
-        &[StudentInput { grade: 1, class_num: 1, number: 1, name: "원래".to_string() }],
+        &[StudentInput {
+            grade: 1,
+            class_num: 1,
+            number: 1,
+            name: "원래".to_string(),
+        }],
         Some(key),
-    ).unwrap();
+    )
+    .unwrap();
     // 2차 갱신
     bulk_upsert_students_impl(
         &conn,
-        &[StudentInput { grade: 1, class_num: 1, number: 1, name: "변경".to_string() }],
+        &[StudentInput {
+            grade: 1,
+            class_num: 1,
+            number: 1,
+            name: "변경".to_string(),
+        }],
         Some(key),
-    ).unwrap();
+    )
+    .unwrap();
 
     let students = get_students_impl(&conn, Some(key)).unwrap();
     assert_eq!(students[0].name, "변경");
@@ -122,7 +154,14 @@ fn test_upsert_record_with_key_stores_encrypted_content() {
     let act_id = insert_activity(&conn, "발표");
     let stu_id = insert_student(&conn, 1, 1, 1, "홍길동");
 
-    upsert_record_impl(&conn, act_id, stu_id, "리더십이 뛰어난 학생입니다.", Some(key)).unwrap();
+    upsert_record_impl(
+        &conn,
+        act_id,
+        stu_id,
+        "리더십이 뛰어난 학생입니다.",
+        Some(key),
+    )
+    .unwrap();
 
     let raw: String = conn
         .query_row(
@@ -131,7 +170,10 @@ fn test_upsert_record_with_key_stores_encrypted_content() {
             |r| r.get(0),
         )
         .unwrap();
-    assert_ne!(raw, "리더십이 뛰어난 학생입니다.", "DB에 평문이 저장되면 안 된다");
+    assert_ne!(
+        raw, "리더십이 뛰어난 학생입니다.",
+        "DB에 평문이 저장되면 안 된다"
+    );
     assert!(raw.contains(':'), "nonce:ciphertext 형식이어야 한다");
 }
 
@@ -165,11 +207,13 @@ fn test_get_area_grid_with_key_decrypts_content_and_name() {
     conn.execute(
         "INSERT INTO AreaActivity (area_id, activity_id) VALUES (?1, ?2)",
         rusqlite::params![area_id, act_id],
-    ).unwrap();
+    )
+    .unwrap();
     conn.execute(
         "INSERT INTO AreaStudent (area_id, student_id) VALUES (?1, ?2)",
         rusqlite::params![area_id, stu_id],
-    ).unwrap();
+    )
+    .unwrap();
     upsert_record_impl(&conn, act_id, stu_id, "독후감 내용", Some(key)).unwrap();
 
     let grid = get_area_grid_impl(&conn, area_id, Some(key)).unwrap();
@@ -199,11 +243,15 @@ fn test_get_record_history_with_key_decrypts_content() {
          SELECT id, content, '2024-01-01 10:00:00', NULL FROM ActivityRecord
          WHERE activity_id=?1 AND student_id=?2",
         rusqlite::params![act_id, stu_id],
-    ).unwrap();
+    )
+    .unwrap();
 
     let history = get_record_history_impl(&conn, act_id, stu_id, 10, 0, Some(key)).unwrap();
     assert_eq!(history.len(), 1);
-    assert_eq!(history[0].content, "발표 내용", "복호화된 히스토리 content여야 한다");
+    assert_eq!(
+        history[0].content, "발표 내용",
+        "복호화된 히스토리 content여야 한다"
+    );
     // DB에는 여전히 암호화 값이 저장되어 있어야 한다
     assert!(encrypted_content.contains(':'));
 }
@@ -233,7 +281,10 @@ fn test_get_records_for_scope_all_without_key_returns_encrypted() {
 
     let records = get_records_for_scope(&conn, "all", &[], None).unwrap();
     assert_eq!(records.len(), 1);
-    assert_ne!(records[0].content, "기록 내용", "키 없이 조회하면 암호화된 값이 나와야 한다");
+    assert_ne!(
+        records[0].content, "기록 내용",
+        "키 없이 조회하면 암호화된 값이 나와야 한다"
+    );
 }
 
 #[test]
@@ -246,11 +297,13 @@ fn test_get_records_for_scope_areas_with_key_decrypts() {
     conn.execute(
         "INSERT INTO AreaActivity (area_id, activity_id) VALUES (?1, ?2)",
         rusqlite::params![area_id, act_id],
-    ).unwrap();
+    )
+    .unwrap();
     conn.execute(
         "INSERT INTO AreaStudent (area_id, student_id) VALUES (?1, ?2)",
         rusqlite::params![area_id, stu_id],
-    ).unwrap();
+    )
+    .unwrap();
     upsert_record_impl(&conn, act_id, stu_id, "영역별 내용", Some(key)).unwrap();
 
     let records = get_records_for_scope(&conn, "areas", &[area_id], Some(key)).unwrap();
@@ -303,28 +356,27 @@ fn test_decrypt_plaintext_with_key_returns_error() {
 
 #[test]
 fn test_encrypt_then_decrypt_all_data_restores_plaintext() {
-    use crate::crypto::{decrypt, encrypt};
-
     let conn = setup_test_db();
-    let key = test_key();
+    let crypto = crypto_state(None);
 
     // 1. 평문으로 데이터 삽입
     let act_id = insert_activity(&conn, "활동");
     let stu_id = insert_student(&conn, 1, 1, 1, "홍길동");
-    conn.execute(
-        "INSERT INTO ActivityRecord (activity_id, student_id, content) VALUES (?1, ?2, ?3)",
-        rusqlite::params![act_id, stu_id, "활동 기록"],
-    ).unwrap();
+    upsert_record_impl(&conn, act_id, stu_id, "활동 기록", None).unwrap();
+    save_snapshot_internal(&conn, act_id, stu_id, Some("before encryption")).unwrap();
 
-    // 2. 수동으로 각 테이블 암호화 (enable_encryption의 핵심 로직)
+    enable_encryption_impl(&conn, &crypto, "password").unwrap();
+    let status = get_encryption_status_impl(&conn, &crypto).unwrap();
+    assert!(status.enabled);
+    assert!(status.unlocked);
+
     let raw_name: String = conn
-        .query_row("SELECT name FROM Student WHERE id=?1", rusqlite::params![stu_id], |r| r.get(0))
+        .query_row(
+            "SELECT name FROM Student WHERE id=?1",
+            rusqlite::params![stu_id],
+            |r| r.get(0),
+        )
         .unwrap();
-    conn.execute(
-        "UPDATE Student SET name=?1 WHERE id=?2",
-        rusqlite::params![encrypt(&raw_name, &key).unwrap(), stu_id],
-    ).unwrap();
-
     let raw_content: String = conn
         .query_row(
             "SELECT content FROM ActivityRecord WHERE activity_id=?1 AND student_id=?2",
@@ -332,25 +384,65 @@ fn test_encrypt_then_decrypt_all_data_restores_plaintext() {
             |r| r.get(0),
         )
         .unwrap();
-    conn.execute(
-        "UPDATE ActivityRecord SET content=?1 WHERE activity_id=?2 AND student_id=?3",
-        rusqlite::params![encrypt(&raw_content, &key).unwrap(), act_id, stu_id],
-    ).unwrap();
+    let raw_history: String = conn
+        .query_row(
+            "SELECT content FROM ActivityRecordHistory LIMIT 1",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_ne!(raw_name, "홍길동");
+    assert_ne!(raw_content, "활동 기록");
+    assert_ne!(raw_history, "활동 기록");
 
-    // 3. 암호화 상태에서 _impl 으로 읽기
-    let students = get_students_impl(&conn, Some(key)).unwrap();
+    // 2. 암호화 상태에서 _impl 으로 읽기
+    let key = resolve_data_key(&conn, &crypto).unwrap();
+    let students = get_students_impl(&conn, key).unwrap();
     assert_eq!(students[0].name, "홍길동");
 
-    // 4. 수동으로 복호화 (disable_encryption의 핵심 로직)
-    let enc_name: String = conn
-        .query_row("SELECT name FROM Student WHERE id=?1", rusqlite::params![stu_id], |r| r.get(0))
-        .unwrap();
-    conn.execute(
-        "UPDATE Student SET name=?1 WHERE id=?2",
-        rusqlite::params![decrypt(&enc_name, &key).unwrap(), stu_id],
-    ).unwrap();
+    // 3. 복호화 후 None 키로 읽으면 평문이 나와야 한다
+    disable_encryption_impl(&conn, &crypto).unwrap();
+    let status = get_encryption_status_impl(&conn, &crypto).unwrap();
+    assert!(!status.enabled);
+    assert!(!status.unlocked);
 
-    // 5. 복호화 후 None 키로 읽으면 평문이 나와야 한다
     let students = get_students_impl(&conn, None).unwrap();
+    assert_eq!(students[0].name, "홍길동");
+    let content: String = conn
+        .query_row(
+            "SELECT content FROM ActivityRecord WHERE activity_id=?1 AND student_id=?2",
+            rusqlite::params![act_id, stu_id],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(content, "활동 기록");
+}
+
+#[test]
+fn test_resolve_data_key_requires_unlock_when_enabled() {
+    let conn = setup_test_db();
+    let crypto = crypto_state(None);
+    set_config_impl(&conn, "encryption_enabled", "true").unwrap();
+
+    let err = resolve_data_key(&conn, &crypto).unwrap_err();
+    assert!(err.contains("잠금"), "에러 메시지: {err}");
+}
+
+#[test]
+fn test_change_password_requires_new_password_afterward() {
+    let conn = setup_test_db();
+    let crypto = crypto_state(None);
+    let stu_id = insert_student(&conn, 1, 1, 1, "홍길동");
+
+    enable_encryption_impl(&conn, &crypto, "old-password").unwrap();
+    change_encryption_password_impl(&conn, &crypto, "old-password", "new-password").unwrap();
+
+    clear_crypto_state(&crypto).unwrap();
+    assert!(unlock_encryption_impl(&conn, &crypto, "old-password").is_err());
+    unlock_encryption_impl(&conn, &crypto, "new-password").unwrap();
+
+    let key = resolve_data_key(&conn, &crypto).unwrap();
+    let students = get_students_impl(&conn, key).unwrap();
+    assert_eq!(students[0].id, stu_id);
     assert_eq!(students[0].name, "홍길동");
 }

--- a/src-tauri/src/tests/crypto_cmd_tests.rs
+++ b/src-tauri/src/tests/crypto_cmd_tests.rs
@@ -798,6 +798,193 @@ fn test_disable_encryption_with_blank_name_student() {
     std::fs::remove_dir_all(&tmp_dir).ok();
 }
 
+// ── 통합 시나리오 테스트 ──────────────────────────────────────────
+
+#[test]
+fn test_full_workflow_with_encryption() {
+    // 전체 파이프라인: enable → import → replace → disable
+    let conn = setup_test_db();
+    let crypto = crypto_state(None);
+    let (db_path, tmp_dir) = setup_temp_db_path_state();
+
+    let area_id = insert_area(&conn, "국어", 500);
+    let act_id = insert_activity(&conn, "발표");
+    conn.execute(
+        "INSERT INTO AreaActivity (area_id, activity_id) VALUES (?1, ?2)",
+        rusqlite::params![area_id, act_id],
+    )
+    .unwrap();
+
+    // 1. 암호화 활성화
+    enable_encryption_impl(&conn, &crypto, &db_path, "password").unwrap();
+    let key = resolve_data_key(&conn, &crypto).unwrap().unwrap();
+
+    // 2. 암호화 상태에서 학생/기록 임포트
+    bulk_import_records_impl(
+        &conn,
+        &[make_import(1, 1, 1, Some("홍길동"), act_id, "가나다 발표 내용")],
+        Some(key),
+    )
+    .unwrap();
+
+    let stu_id: i64 = conn
+        .query_row("SELECT id FROM Student WHERE grade=1", [], |r| r.get(0))
+        .unwrap();
+    conn.execute(
+        "INSERT INTO AreaStudent (area_id, student_id) VALUES (?1, ?2)",
+        rusqlite::params![area_id, stu_id],
+    )
+    .unwrap();
+
+    // 3. 치환 규칙 적용 (가나다 → ABC)
+    create_replace_rule_db(&conn, "가나다", "ABC", false, 1).unwrap();
+    let mut cache = make_cache();
+    let replace_result = apply_replace_impl(&conn, "all", &[], Some(key), &mut cache).unwrap();
+    assert_eq!(replace_result.changed_count, 1);
+
+    // 4. 암호화 상태에서 치환된 결과 확인
+    let grid_encrypted = get_area_grid_impl(&conn, area_id, Some(key)).unwrap();
+    assert_eq!(grid_encrypted.records[0].content, "ABC 발표 내용");
+    assert_eq!(grid_encrypted.students[0].name, "홍길동");
+
+    // DB에는 암호화된 값이 저장되어야 한다
+    let raw: String = conn
+        .query_row(
+            "SELECT content FROM ActivityRecord WHERE activity_id=?1 AND student_id=?2",
+            rusqlite::params![act_id, stu_id],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_ne!(raw, "ABC 발표 내용", "치환 결과가 평문으로 저장되면 안 된다");
+
+    // 5. 암호화 비활성화
+    disable_encryption_impl(&conn, &crypto, &db_path).unwrap();
+
+    // 6. None 키로 동일한 평문이 조회되어야 한다
+    let grid_plain = get_area_grid_impl(&conn, area_id, None).unwrap();
+    assert_eq!(grid_plain.records[0].content, "ABC 발표 내용");
+    assert_eq!(grid_plain.students[0].name, "홍길동");
+
+    std::fs::remove_dir_all(&tmp_dir).ok();
+}
+
+#[test]
+fn test_encrypt_state_transitions() {
+    // 상태 A: 암호화 비활성화 → resolve_data_key → Ok(None)
+    let conn = setup_test_db();
+    let crypto = crypto_state(None);
+    let (db_path, tmp_dir) = setup_temp_db_path_state();
+
+    let key_a = resolve_data_key(&conn, &crypto).unwrap();
+    assert!(key_a.is_none(), "암호화 비활성화 상태에서 key는 None이어야 한다");
+
+    // 상태 B: 활성화 + 잠금 → resolve_data_key → Err("잠금")
+    enable_encryption_impl(&conn, &crypto, &db_path, "password").unwrap();
+    clear_crypto_state(&crypto).unwrap(); // 잠금 상태로 전환
+    let err = resolve_data_key(&conn, &crypto).unwrap_err();
+    assert!(err.contains("잠금"), "잠금 상태 에러 메시지: {err}");
+
+    // 상태 C: 활성화 + 해제 → resolve_data_key → Ok(Some(key))
+    unlock_encryption_impl(&conn, &crypto, "password").unwrap();
+    let key_c = resolve_data_key(&conn, &crypto).unwrap();
+    assert!(key_c.is_some(), "해제 상태에서 key는 Some이어야 한다");
+    assert_ne!(key_c.unwrap(), [0u8; 32], "key는 영벡터가 아니어야 한다");
+
+    std::fs::remove_dir_all(&tmp_dir).ok();
+}
+
+#[test]
+fn test_replace_then_history_roundtrip_with_encryption() {
+    // apply_replace 후 get_record_history_impl로 history 평문 검증
+    // (apply_replace는 치환된 새 content를 history에 저장)
+    let conn = setup_test_db();
+    let key = test_key();
+    let area_id = insert_area(&conn, "국어", 500);
+    let act_id = insert_activity(&conn, "발표");
+    let stu_id = create_student_impl(&conn, 1, 1, 1, "홍길동", Some(key)).unwrap();
+    conn.execute(
+        "INSERT INTO AreaActivity (area_id, activity_id) VALUES (?1, ?2)",
+        rusqlite::params![area_id, act_id],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO AreaStudent (area_id, student_id) VALUES (?1, ?2)",
+        rusqlite::params![area_id, stu_id],
+    )
+    .unwrap();
+
+    upsert_record_impl(&conn, act_id, stu_id, "원본 내용 ABC", Some(key)).unwrap();
+
+    create_replace_rule_db(&conn, "ABC", "XYZ", false, 1).unwrap();
+    let mut cache = make_cache();
+    apply_replace_impl(&conn, "all", &[], Some(key), &mut cache).unwrap();
+
+    // 현재 content가 복호화되어야 한다
+    let grid = get_area_grid_impl(&conn, area_id, Some(key)).unwrap();
+    assert_eq!(grid.records[0].content, "원본 내용 XYZ");
+
+    // history가 존재하며 모든 항목이 복호화된 평문이어야 한다
+    let history = get_record_history_impl(&conn, act_id, stu_id, 10, 0, Some(key)).unwrap();
+    assert!(!history.is_empty(), "치환 적용 후 history가 있어야 한다");
+    for entry in &history {
+        assert!(
+            !entry.content.contains(':') || entry.content.is_empty(),
+            "history content가 암호화된 ciphertext 형식이면 안 된다: {}",
+            entry.content
+        );
+    }
+    // 가장 최근 history의 content는 치환된 결과여야 한다
+    assert_eq!(history[0].content, "원본 내용 XYZ", "history[0]이 복호화된 치환 결과여야 한다");
+}
+
+#[test]
+fn test_bulk_import_then_inspect_with_encryption() {
+    // 여러 학생 대량 임포트 후 inspect 결과가 모두 평문인지 검증
+    let conn = setup_test_db();
+    let key = test_key();
+    let act_id = insert_activity(&conn, "발표");
+
+    bulk_import_records_impl(
+        &conn,
+        &[
+            make_import(1, 1, 1, Some("홍길동"), act_id, "우수한 발표 내용"),
+            make_import(1, 1, 2, Some("이순신"), act_id, "성실한 태도 기록"),
+            make_import(1, 1, 3, Some("강감찬"), act_id, "창의적인 발표"),
+        ],
+        Some(key),
+    )
+    .unwrap();
+
+    // DB에는 암호화된 값이 저장되어야 한다
+    let raw_names: Vec<String> = {
+        let mut stmt = conn
+            .prepare("SELECT name FROM Student ORDER BY number")
+            .unwrap();
+        stmt.query_map([], |r| r.get(0))
+            .unwrap()
+            .map(|r| r.unwrap())
+            .collect()
+    };
+    for name in &raw_names {
+        assert!(name.contains(':'), "DB 이름이 암호화 형식이어야 한다: {name}");
+    }
+
+    // Some(key)로 inspect 조회 → 모든 필드가 평문이어야 한다
+    let records =
+        get_all_records_for_inspect_impl(&conn, "all", vec![], Some(key)).unwrap();
+    assert_eq!(records.len(), 3, "3개 기록이 반환되어야 한다");
+
+    let names: Vec<&str> = records.iter().map(|r| r.student_name.as_str()).collect();
+    assert!(names.contains(&"홍길동"), "홍길동이 복호화되어야 한다");
+    assert!(names.contains(&"이순신"), "이순신이 복호화되어야 한다");
+    assert!(names.contains(&"강감찬"), "강감찬이 복호화되어야 한다");
+
+    let contents: Vec<&str> = records.iter().map(|r| r.content.as_str()).collect();
+    assert!(contents.contains(&"우수한 발표 내용"));
+    assert!(contents.contains(&"성실한 태도 기록"));
+    assert!(contents.contains(&"창의적인 발표"));
+}
+
 // ── bulk_import 후 history 복호화 조합 테스트 ────────────────────
 
 #[test]

--- a/src-tauri/src/tests/crypto_cmd_tests.rs
+++ b/src-tauri/src/tests/crypto_cmd_tests.rs
@@ -8,8 +8,10 @@ use crate::commands::record::{
     bulk_import_records_impl, get_area_grid_impl, get_record_history_impl,
     preview_import_records_impl, save_snapshot_internal, upsert_record_impl,
 };
+use crate::commands::replace::{apply_replace_impl, create_replace_rule_db, preview_replace_impl};
 use crate::commands::snapshot::{create_snapshot_impl, restore_snapshot_impl};
 use crate::commands::synonym::get_all_records_for_inspect_impl;
+use crate::state::ReplaceCache;
 use crate::commands::student::{
     bulk_upsert_students_impl, create_student_impl, get_students_impl, update_student_impl,
 };
@@ -682,4 +684,152 @@ fn test_restore_snapshot_with_encryption() {
         grid_restored.records[0].content, "v1 내용",
         "스냅샷 복원 후 암호화된 v1 내용이 복호화되어야 한다"
     );
+}
+
+// ── preview_replace / apply_replace: 암호화 경로 ─────────────────
+
+fn make_cache() -> ReplaceCache {
+    ReplaceCache {
+        ruleset_version: 0,
+        entries: std::collections::HashMap::new(),
+    }
+}
+
+#[test]
+fn test_preview_replace_with_key_shows_decrypted_content() {
+    let conn = setup_test_db();
+    let key = test_key();
+    let act_id = insert_activity(&conn, "발표");
+    let stu_id = create_student_impl(&conn, 1, 1, 1, "홍길동", Some(key)).unwrap();
+    upsert_record_impl(&conn, act_id, stu_id, "가나다 발표", Some(key)).unwrap();
+
+    create_replace_rule_db(&conn, "가나다", "ABC", false, 1).unwrap();
+
+    let mut cache = make_cache();
+    let items = preview_replace_impl(&conn, "all", &[], Some(key), &mut cache).unwrap();
+
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0].original, "가나다 발표", "preview의 원본이 복호화된 평문이어야 한다");
+    assert_eq!(items[0].result, "ABC 발표");
+    assert_eq!(items[0].student_name, "홍길동", "student_name이 복호화되어야 한다");
+}
+
+#[test]
+fn test_apply_replace_with_key_reencrypts_result() {
+    let conn = setup_test_db();
+    let key = test_key();
+    let area_id = insert_area(&conn, "국어", 500);
+    let act_id = insert_activity(&conn, "발표");
+    let stu_id = create_student_impl(&conn, 1, 1, 1, "홍길동", Some(key)).unwrap();
+    conn.execute(
+        "INSERT INTO AreaActivity (area_id, activity_id) VALUES (?1, ?2)",
+        rusqlite::params![area_id, act_id],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO AreaStudent (area_id, student_id) VALUES (?1, ?2)",
+        rusqlite::params![area_id, stu_id],
+    )
+    .unwrap();
+    upsert_record_impl(&conn, act_id, stu_id, "가나다 발표", Some(key)).unwrap();
+
+    create_replace_rule_db(&conn, "가나다", "ABC", false, 1).unwrap();
+
+    let mut cache = make_cache();
+    let result = apply_replace_impl(&conn, "all", &[], Some(key), &mut cache).unwrap();
+    assert_eq!(result.changed_count, 1);
+
+    // DB에 재암호화된 값이 저장되어야 한다
+    let raw: String = conn
+        .query_row(
+            "SELECT content FROM ActivityRecord WHERE activity_id=?1 AND student_id=?2",
+            rusqlite::params![act_id, stu_id],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_ne!(raw, "ABC 발표", "치환 결과가 평문으로 저장되면 안 된다");
+    assert!(raw.contains(':'), "재암호화된 nonce:ciphertext 형식이어야 한다");
+
+    // Some(key)로 읽으면 치환된 평문이 복호화되어야 한다
+    let grid = get_area_grid_impl(&conn, area_id, Some(key)).unwrap();
+    assert_eq!(grid.records[0].content, "ABC 발표", "치환 후 복호화하면 치환된 원문이어야 한다");
+
+    // 치환 이력도 history에 암호화된 채로 저장되고 복호화 가능해야 한다
+    let history = get_record_history_impl(&conn, act_id, stu_id, 10, 0, Some(key)).unwrap();
+    assert!(!history.is_empty(), "치환 적용 시 history가 생성되어야 한다");
+    assert_eq!(history[0].content, "ABC 발표", "history content도 복호화되어야 한다");
+}
+
+// ── disable_encryption + 빈 이름 학생 회귀 테스트 ─────────────────
+
+#[test]
+fn test_disable_encryption_with_blank_name_student() {
+    let conn = setup_test_db();
+    let crypto = crypto_state(None);
+    let (db_path, tmp_dir) = setup_temp_db_path_state();
+
+    let act_id = insert_activity(&conn, "발표");
+
+    // 암호화 활성화
+    enable_encryption_impl(&conn, &crypto, &db_path, "password").unwrap();
+    let key = resolve_data_key(&conn, &crypto).unwrap();
+
+    // 암호화 활성화 후 빈 이름 학생 생성 (버그 시나리오)
+    let stu_id = create_student_impl(&conn, 1, 1, 1, "", Some(key.unwrap())).unwrap();
+    upsert_record_impl(&conn, act_id, stu_id, "기록 내용", key).unwrap();
+
+    // disable_encryption이 실패 없이 완료되어야 한다 (이것이 수정된 버그)
+    let result = disable_encryption_impl(&conn, &crypto, &db_path);
+    assert!(result.is_ok(), "빈 이름 학생이 있어도 disable_encryption이 성공해야 한다: {:?}", result);
+
+    // 복호화 후 데이터 무결성 확인
+    let students = get_students_impl(&conn, None).unwrap();
+    assert_eq!(students[0].name, "", "복호화 후 빈 이름이 유지되어야 한다");
+
+    let content: String = conn
+        .query_row(
+            "SELECT content FROM ActivityRecord WHERE activity_id=?1",
+            rusqlite::params![act_id],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(content, "기록 내용", "복호화 후 record content가 평문으로 복원되어야 한다");
+
+    std::fs::remove_dir_all(&tmp_dir).ok();
+}
+
+// ── bulk_import 후 history 복호화 조합 테스트 ────────────────────
+
+#[test]
+fn test_bulk_import_history_readable_with_key() {
+    let conn = setup_test_db();
+    let key = test_key();
+    let act_id = insert_activity(&conn, "발표");
+
+    bulk_import_records_impl(
+        &conn,
+        &[make_import(1, 1, 1, Some("홍길동"), act_id, "발표 내용")],
+        Some(key),
+    )
+    .unwrap();
+
+    // bulk_import는 content가 있으면 history에도 암호화된 채로 복사한다
+    // get_record_history_impl이 그것을 복호화해서 반환해야 한다
+    let stu_id: i64 = conn
+        .query_row("SELECT id FROM Student WHERE grade=1", [], |r| r.get(0))
+        .unwrap();
+
+    let history = get_record_history_impl(&conn, act_id, stu_id, 10, 0, Some(key)).unwrap();
+    assert_eq!(history.len(), 1, "bulk_import 후 history가 1개 생성되어야 한다");
+    assert_eq!(
+        history[0].content, "발표 내용",
+        "bulk_import로 저장된 history content가 복호화되어야 한다"
+    );
+
+    // history에 암호화된 값이 저장되어 있어야 한다 (None으로 읽으면 ciphertext)
+    let raw_history: String = conn
+        .query_row("SELECT content FROM ActivityRecordHistory LIMIT 1", [], |r| r.get(0))
+        .unwrap();
+    assert_ne!(raw_history, "발표 내용", "history DB에는 암호화된 값이 있어야 한다");
+    assert!(raw_history.contains(':'));
 }

--- a/src-tauri/src/tests/crypto_cmd_tests.rs
+++ b/src-tauri/src/tests/crypto_cmd_tests.rs
@@ -924,17 +924,10 @@ fn test_replace_then_history_roundtrip_with_encryption() {
     let grid = get_area_grid_impl(&conn, area_id, Some(key)).unwrap();
     assert_eq!(grid.records[0].content, "원본 내용 XYZ");
 
-    // history가 존재하며 모든 항목이 복호화된 평문이어야 한다
+    // apply_replace는 치환 후 새 content를 history에 저장한다.
+    // upsert_record_impl만으로는 history가 생성되지 않으므로 항목은 1개여야 한다.
     let history = get_record_history_impl(&conn, act_id, stu_id, 10, 0, Some(key)).unwrap();
-    assert!(!history.is_empty(), "치환 적용 후 history가 있어야 한다");
-    for entry in &history {
-        assert!(
-            !entry.content.contains(':') || entry.content.is_empty(),
-            "history content가 암호화된 ciphertext 형식이면 안 된다: {}",
-            entry.content
-        );
-    }
-    // 가장 최근 history의 content는 치환된 결과여야 한다
+    assert_eq!(history.len(), 1, "apply_replace 후 history는 정확히 1개여야 한다");
     assert_eq!(history[0].content, "원본 내용 XYZ", "history[0]이 복호화된 치환 결과여야 한다");
 }
 

--- a/src-tauri/src/tests/crypto_cmd_tests.rs
+++ b/src-tauri/src/tests/crypto_cmd_tests.rs
@@ -42,7 +42,6 @@ fn test_create_student_with_key_stores_encrypted_name() {
         .query_row("SELECT name FROM Student WHERE grade=1", [], |r| r.get(0))
         .unwrap();
     assert_ne!(raw_name, "홍길동", "DB에 평문이 저장되면 안 된다");
-    assert!(raw_name.contains(':'), "nonce:ciphertext 형식이어야 한다");
 }
 
 #[test]
@@ -180,7 +179,6 @@ fn test_upsert_record_with_key_stores_encrypted_content() {
         raw, "리더십이 뛰어난 학생입니다.",
         "DB에 평문이 저장되면 안 된다"
     );
-    assert!(raw.contains(':'), "nonce:ciphertext 형식이어야 한다");
 }
 
 #[test]
@@ -259,7 +257,11 @@ fn test_get_record_history_with_key_decrypts_content() {
         "복호화된 히스토리 content여야 한다"
     );
     // DB에는 여전히 암호화 값이 저장되어 있어야 한다
-    assert!(encrypted_content.contains(':'));
+    // — 평문과 달라야 하고, 올바른 키로 복호화하면 원문이 나와야 한다
+    assert_ne!(encrypted_content, "발표 내용", "DB에 평문이 저장되면 안 된다");
+    let decrypted = crate::crypto::decrypt(&encrypted_content, &key)
+        .expect("유효한 암호문이어야 한다");
+    assert_eq!(decrypted, "발표 내용", "올바른 키로 복호화하면 원문이어야 한다");
 }
 
 // ── engine: get_records_for_scope ─────────────────────────────────
@@ -522,7 +524,6 @@ fn test_bulk_import_records_with_key() {
         .query_row("SELECT name FROM Student WHERE grade=1", [], |r| r.get(0))
         .unwrap();
     assert_ne!(raw_name, "홍길동", "이름이 평문으로 저장되면 안 된다");
-    assert!(raw_name.contains(':'), "nonce:ciphertext 형식이어야 한다");
 
     let raw_content: String = conn
         .query_row(
@@ -532,7 +533,6 @@ fn test_bulk_import_records_with_key() {
         )
         .unwrap();
     assert_ne!(raw_content, "발표 내용", "content가 평문으로 저장되면 안 된다");
-    assert!(raw_content.contains(':'));
 
     // Some(key)로 읽으면 복호화된 원문이 나와야 한다
     conn.execute(
@@ -571,7 +571,6 @@ fn test_bulk_import_records_with_key_existing_empty_name() {
         .query_row("SELECT name FROM Student WHERE grade=1", [], |r| r.get(0))
         .unwrap();
     assert_ne!(raw_name, "새이름");
-    assert!(raw_name.contains(':'));
 }
 
 // ── preview_import_records: 암호화 경로 ──────────────────────────
@@ -749,7 +748,6 @@ fn test_apply_replace_with_key_reencrypts_result() {
         )
         .unwrap();
     assert_ne!(raw, "ABC 발표", "치환 결과가 평문으로 저장되면 안 된다");
-    assert!(raw.contains(':'), "재암호화된 nonce:ciphertext 형식이어야 한다");
 
     // Some(key)로 읽으면 치환된 평문이 복호화되어야 한다
     let grid = get_area_grid_impl(&conn, area_id, Some(key)).unwrap();
@@ -950,6 +948,8 @@ fn test_bulk_import_then_inspect_with_encryption() {
     .unwrap();
 
     // DB에는 암호화된 값이 저장되어야 한다
+    // — 평문과 달라야 하고, 올바른 키로 복호화하면 원문이 나와야 한다
+    let expected_names = ["홍길동", "이순신", "강감찬"];
     let raw_names: Vec<String> = {
         let mut stmt = conn
             .prepare("SELECT name FROM Student ORDER BY number")
@@ -959,8 +959,11 @@ fn test_bulk_import_then_inspect_with_encryption() {
             .map(|r| r.unwrap())
             .collect()
     };
-    for name in &raw_names {
-        assert!(name.contains(':'), "DB 이름이 암호화 형식이어야 한다: {name}");
+    for (raw, expected) in raw_names.iter().zip(expected_names.iter()) {
+        assert_ne!(raw, expected, "DB에 평문이 저장되면 안 된다: {raw}");
+        let decrypted = crate::crypto::decrypt(raw, &key)
+            .unwrap_or_else(|e| panic!("유효한 암호문이어야 한다 ({raw}): {e}"));
+        assert_eq!(&decrypted, expected, "올바른 키로 복호화하면 원문이어야 한다");
     }
 
     // Some(key)로 inspect 조회 → 모든 필드가 평문이어야 한다
@@ -1012,7 +1015,6 @@ fn test_bulk_import_history_readable_with_key() {
         .query_row("SELECT content FROM ActivityRecordHistory LIMIT 1", [], |r| r.get(0))
         .unwrap();
     assert_ne!(raw_history, "발표 내용", "history DB에는 암호화된 값이 있어야 한다");
-    assert!(raw_history.contains(':'));
 }
 
 // ── 파일 DB 재시작 시나리오 ───────────────────────────────────────────
@@ -1213,7 +1215,6 @@ fn test_restore_plaintext_snapshot_after_encryption_enabled() {
         )
         .unwrap();
     assert_ne!(raw, "v1 내용", "복원 후에도 DB에는 암호화된 값이 저장되어야 한다");
-    assert!(raw.contains(':'), "복원된 값이 nonce:ciphertext 형식이어야 한다");
 
     std::fs::remove_dir_all(&tmp_dir).ok();
 }

--- a/src-tauri/src/tests/crypto_tests.rs
+++ b/src-tauri/src/tests/crypto_tests.rs
@@ -1,0 +1,187 @@
+use crate::crypto::{decrypt, derive_key, encrypt, generate_salt, maybe_decrypt, maybe_encrypt};
+
+// ── derive_key ────────────────────────────────────────────────────
+
+#[test]
+fn test_derive_key_is_deterministic() {
+    let salt = [1u8; 16];
+    let key1 = derive_key("비밀번호", &salt);
+    let key2 = derive_key("비밀번호", &salt);
+    assert_eq!(key1, key2);
+}
+
+#[test]
+fn test_derive_key_different_passwords_produce_different_keys() {
+    let salt = [42u8; 16];
+    let key_a = derive_key("password_a", &salt);
+    let key_b = derive_key("password_b", &salt);
+    assert_ne!(key_a, key_b);
+}
+
+#[test]
+fn test_derive_key_different_salts_produce_different_keys() {
+    let key_a = derive_key("same_password", &[0u8; 16]);
+    let key_b = derive_key("same_password", &[1u8; 16]);
+    assert_ne!(key_a, key_b);
+}
+
+#[test]
+fn test_derive_key_output_is_32_bytes() {
+    let key = derive_key("test", &[0u8; 16]);
+    assert_eq!(key.len(), 32);
+}
+
+// ── generate_salt ─────────────────────────────────────────────────
+
+#[test]
+fn test_generate_salt_is_16_bytes() {
+    let salt = generate_salt();
+    assert_eq!(salt.len(), 16);
+}
+
+#[test]
+fn test_generate_salt_produces_different_values() {
+    let s1 = generate_salt();
+    let s2 = generate_salt();
+    // 극히 낮은 확률로 같을 수 있으나 CSPRNG이면 사실상 불가
+    assert_ne!(s1, s2, "두 번 호출한 salt가 같으면 RNG가 고장난 것");
+}
+
+// ── encrypt / decrypt ─────────────────────────────────────────────
+
+#[test]
+fn test_encrypt_decrypt_roundtrip_ascii() {
+    let key = derive_key("test_password", &[7u8; 16]);
+    let plaintext = "Hello, World!";
+    let ciphertext = encrypt(plaintext, &key).unwrap();
+    let recovered = decrypt(&ciphertext, &key).unwrap();
+    assert_eq!(recovered, plaintext);
+}
+
+#[test]
+fn test_encrypt_decrypt_roundtrip_korean() {
+    let key = derive_key("비밀번호1234", &[9u8; 16]);
+    let plaintext = "홍길동은 활발하고 리더십이 뛰어나며 학급 회의를 주도적으로 이끌었다.";
+    let ciphertext = encrypt(plaintext, &key).unwrap();
+    let recovered = decrypt(&ciphertext, &key).unwrap();
+    assert_eq!(recovered, plaintext);
+}
+
+#[test]
+fn test_encrypt_same_plaintext_produces_different_ciphertext() {
+    let key = derive_key("pw", &[3u8; 16]);
+    let c1 = encrypt("동일한 내용", &key).unwrap();
+    let c2 = encrypt("동일한 내용", &key).unwrap();
+    // nonce가 매번 랜덤이므로 결과가 달라야 한다
+    assert_ne!(c1, c2, "매번 다른 nonce를 써야 한다");
+}
+
+#[test]
+fn test_decrypt_wrong_key_returns_error() {
+    let key_enc = derive_key("correct_key", &[1u8; 16]);
+    let key_dec = derive_key("wrong_key", &[1u8; 16]);
+    let ciphertext = encrypt("비밀 내용", &key_enc).unwrap();
+    let result = decrypt(&ciphertext, &key_dec);
+    assert!(result.is_err(), "잘못된 키로 복호화하면 에러여야 한다");
+    let err = result.unwrap_err();
+    assert!(err.contains("복호화 실패"), "에러 메시지: {err}");
+}
+
+#[test]
+fn test_decrypt_malformed_no_colon_returns_error() {
+    let key = derive_key("pw", &[0u8; 16]);
+    let result = decrypt("invaliddatawithnocolon", &key);
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(err.contains("잘못된 암호화 형식"), "에러 메시지: {err}");
+}
+
+#[test]
+fn test_decrypt_invalid_base64_nonce_returns_error() {
+    let key = derive_key("pw", &[0u8; 16]);
+    let result = decrypt("not!valid!base64:YWJj", &key);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_decrypt_invalid_base64_ciphertext_returns_error() {
+    let key = derive_key("pw", &[0u8; 16]);
+    // 유효한 base64 nonce + 유효하지 않은 ciphertext
+    let result = decrypt("dGVzdA==:not!valid!base64", &key);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_encrypt_output_format_has_colon_separator() {
+    let key = derive_key("pw", &[0u8; 16]);
+    let ciphertext = encrypt("test", &key).unwrap();
+    let colon_count = ciphertext.chars().filter(|&c| c == ':').count();
+    assert_eq!(colon_count, 1, "nonce:ciphertext 형식이어야 한다");
+}
+
+#[test]
+fn test_encrypt_empty_string_roundtrip() {
+    // maybe_encrypt/decrypt가 빈 문자열을 건너뛰므로 직접 encrypt는 성공해야 함
+    let key = derive_key("pw", &[0u8; 16]);
+    let ct = encrypt("", &key).unwrap();
+    let pt = decrypt(&ct, &key).unwrap();
+    assert_eq!(pt, "");
+}
+
+// ── maybe_decrypt ─────────────────────────────────────────────────
+
+#[test]
+fn test_maybe_decrypt_empty_string_returns_empty() {
+    let key = derive_key("pw", &[0u8; 16]);
+    let result = maybe_decrypt(String::new(), Some(key)).unwrap();
+    assert_eq!(result, "");
+}
+
+#[test]
+fn test_maybe_decrypt_no_key_returns_value_unchanged() {
+    let result = maybe_decrypt("평문 데이터".to_string(), None).unwrap();
+    assert_eq!(result, "평문 데이터");
+}
+
+#[test]
+fn test_maybe_decrypt_with_key_decrypts() {
+    let key = derive_key("pass", &[2u8; 16]);
+    let encrypted = encrypt("복호화 대상", &key).unwrap();
+    let result = maybe_decrypt(encrypted, Some(key)).unwrap();
+    assert_eq!(result, "복호화 대상");
+}
+
+// ── maybe_encrypt ─────────────────────────────────────────────────
+
+#[test]
+fn test_maybe_encrypt_empty_string_returns_empty() {
+    let key = derive_key("pw", &[0u8; 16]);
+    let result = maybe_encrypt("", Some(key)).unwrap();
+    assert_eq!(result, "");
+}
+
+#[test]
+fn test_maybe_encrypt_no_key_returns_value_unchanged() {
+    let result = maybe_encrypt("평문 그대로", None).unwrap();
+    assert_eq!(result, "평문 그대로");
+}
+
+#[test]
+fn test_maybe_encrypt_with_key_encrypts() {
+    let key = derive_key("pass", &[5u8; 16]);
+    let result = maybe_encrypt("암호화할 내용", Some(key)).unwrap();
+    // 암호화된 결과는 원문과 달라야 한다
+    assert_ne!(result, "암호화할 내용");
+    // 복호화하면 원문이 나와야 한다
+    let recovered = maybe_decrypt(result, Some(key)).unwrap();
+    assert_eq!(recovered, "암호화할 내용");
+}
+
+#[test]
+fn test_maybe_encrypt_decrypt_roundtrip_consistency() {
+    let key = derive_key("일관성 테스트", &[11u8; 16]);
+    let original = "복호화 일관성 확인용 내용입니다.";
+    let encrypted = maybe_encrypt(original, Some(key)).unwrap();
+    let decrypted = maybe_decrypt(encrypted, Some(key)).unwrap();
+    assert_eq!(decrypted, original);
+}

--- a/src-tauri/src/tests/crypto_tests.rs
+++ b/src-tauri/src/tests/crypto_tests.rs
@@ -112,6 +112,31 @@ fn test_decrypt_invalid_base64_ciphertext_returns_error() {
 }
 
 #[test]
+fn test_decrypt_invalid_nonce_length_returns_error() {
+    let key = derive_key("pw", &[0u8; 16]);
+    let result = decrypt("dGVzdA==:YWJj", &key);
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(err.contains("nonce 길이"), "에러 메시지: {err}");
+}
+
+#[test]
+fn test_encrypt_invalid_key_length_returns_error() {
+    let result = encrypt("test", &[0u8; 31]);
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(err.contains("키 길이"), "에러 메시지: {err}");
+}
+
+#[test]
+fn test_decrypt_invalid_key_length_returns_error() {
+    let result = decrypt("AAAAAAAAAAAAAAAA:YWJj", &[0u8; 31]);
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(err.contains("키 길이"), "에러 메시지: {err}");
+}
+
+#[test]
 fn test_encrypt_output_format_has_colon_separator() {
     let key = derive_key("pw", &[0u8; 16]);
     let ciphertext = encrypt("test", &key).unwrap();

--- a/src-tauri/src/tests/engine_tests.rs
+++ b/src-tauri/src/tests/engine_tests.rs
@@ -262,7 +262,7 @@ fn test_scope_all_returns_nonempty_records() {
     .unwrap();
     insert_record(&conn, act_id, stu_id, "내용있음");
 
-    let records = get_records_for_scope(&conn, "all", &[]).unwrap();
+    let records = get_records_for_scope(&conn, "all", &[], None).unwrap();
     assert_eq!(records.len(), 1);
     assert_eq!(records[0].content, "내용있음");
 }
@@ -274,7 +274,7 @@ fn test_scope_all_excludes_empty_content() {
     let stu_id = insert_student(&conn, 1, 1, 1, "홍길동");
     insert_record(&conn, act_id, stu_id, ""); // 빈 content
 
-    let records = get_records_for_scope(&conn, "all", &[]).unwrap();
+    let records = get_records_for_scope(&conn, "all", &[], None).unwrap();
     assert!(records.is_empty());
 }
 
@@ -301,7 +301,7 @@ fn test_scope_areas_filters_by_area() {
     insert_record(&conn, act1, stu, "영역1 기록");
     insert_record(&conn, act2, stu, "영역2 기록");
 
-    let records = get_records_for_scope(&conn, "areas", &[area1]).unwrap();
+    let records = get_records_for_scope(&conn, "areas", &[area1], None).unwrap();
     assert_eq!(records.len(), 1);
     assert_eq!(records[0].content, "영역1 기록");
 }
@@ -309,13 +309,13 @@ fn test_scope_areas_filters_by_area() {
 #[test]
 fn test_scope_areas_empty_ids_returns_empty() {
     let conn = setup_test_db();
-    let records = get_records_for_scope(&conn, "areas", &[]).unwrap();
+    let records = get_records_for_scope(&conn, "areas", &[], None).unwrap();
     assert!(records.is_empty());
 }
 
 #[test]
 fn test_scope_unknown_returns_error() {
     let conn = setup_test_db();
-    let result = get_records_for_scope(&conn, "invalid_scope", &[]);
+    let result = get_records_for_scope(&conn, "invalid_scope", &[], None);
     assert!(result.is_err());
 }

--- a/src-tauri/src/tests/mod.rs
+++ b/src-tauri/src/tests/mod.rs
@@ -1,4 +1,6 @@
+use crate::state::DbPathState;
 use rusqlite::Connection;
+use std::sync::Mutex;
 
 pub mod engine_tests;
 pub mod db_tests;
@@ -13,6 +15,22 @@ pub mod replace_tests;
 pub mod synonym_tests;
 pub mod crypto_tests;
 pub mod crypto_cmd_tests;
+
+/// 테스트에서 백업 경로가 필요한 경우 사용. 임시 파일을 생성하고 DbPathState를 반환한다.
+/// 반환된 PathBuf(디렉토리)는 테스트 종료 후 직접 삭제해야 한다.
+pub fn setup_temp_db_path_state() -> (DbPathState, std::path::PathBuf) {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let dir = std::env::temp_dir()
+        .join(format!("school_record_path_test_{}_{}", std::process::id(), nanos));
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join("test.db");
+    std::fs::write(&path, b"").unwrap();
+    let state = DbPathState(Mutex::new(Some(path)));
+    (state, dir)
+}
 
 pub fn setup_test_db() -> Connection {
     let conn = Connection::open_in_memory().unwrap();

--- a/src-tauri/src/tests/mod.rs
+++ b/src-tauri/src/tests/mod.rs
@@ -10,6 +10,8 @@ pub mod record_tests;
 pub mod snapshot_tests;
 pub mod replace_tests;
 pub mod synonym_tests;
+pub mod crypto_tests;
+pub mod crypto_cmd_tests;
 
 pub fn setup_test_db() -> Connection {
     let conn = Connection::open_in_memory().unwrap();

--- a/src-tauri/src/tests/mod.rs
+++ b/src-tauri/src/tests/mod.rs
@@ -2,6 +2,7 @@ use rusqlite::Connection;
 
 pub mod engine_tests;
 pub mod db_tests;
+pub mod project_tests;
 pub mod area_tests;
 pub mod activity_tests;
 pub mod config_tests;

--- a/src-tauri/src/tests/project_tests.rs
+++ b/src-tauri/src/tests/project_tests.rs
@@ -1,5 +1,5 @@
 use crate::commands::project::{new_project_impl, open_project_impl};
-use crate::state::{current_crypto_key, CryptoState, CryptoStateHandle, DbState};
+use crate::state::{current_crypto_key, CryptoState, CryptoStateHandle, DbPathState, DbState};
 use std::path::PathBuf;
 use std::sync::Mutex;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -29,9 +29,10 @@ fn test_new_project_clears_crypto_state() {
     std::fs::create_dir(&dir).unwrap();
     let path = dir.join("new.db");
     let db = DbState(Mutex::new(None));
+    let db_path = DbPathState(Mutex::new(None));
     let crypto = crypto_state_with_key();
 
-    new_project_impl(path.to_str().unwrap(), &db, &crypto).unwrap();
+    new_project_impl(path.to_str().unwrap(), &db, &db_path, &crypto).unwrap();
 
     assert!(db.0.lock().unwrap().is_some());
     assert!(current_crypto_key(&crypto).unwrap().is_none());
@@ -48,9 +49,10 @@ fn test_open_project_clears_crypto_state() {
     drop(crate::db::create_new(&path).unwrap());
 
     let db = DbState(Mutex::new(None));
+    let db_path = DbPathState(Mutex::new(None));
     let crypto = crypto_state_with_key();
 
-    open_project_impl(path.to_str().unwrap(), &db, &crypto).unwrap();
+    open_project_impl(path.to_str().unwrap(), &db, &db_path, &crypto).unwrap();
 
     assert!(db.0.lock().unwrap().is_some());
     assert!(current_crypto_key(&crypto).unwrap().is_none());

--- a/src-tauri/src/tests/project_tests.rs
+++ b/src-tauri/src/tests/project_tests.rs
@@ -36,6 +36,7 @@ fn test_new_project_clears_crypto_state() {
     assert!(db.0.lock().unwrap().is_some());
     assert!(current_crypto_key(&crypto).unwrap().is_none());
 
+    drop(db); // Windows: 파일 잠금 해제 후 삭제
     std::fs::remove_dir_all(&dir).unwrap();
 }
 
@@ -54,5 +55,6 @@ fn test_open_project_clears_crypto_state() {
     assert!(db.0.lock().unwrap().is_some());
     assert!(current_crypto_key(&crypto).unwrap().is_none());
 
+    drop(db); // Windows: 파일 잠금 해제 후 삭제
     std::fs::remove_dir_all(&dir).unwrap();
 }

--- a/src-tauri/src/tests/project_tests.rs
+++ b/src-tauri/src/tests/project_tests.rs
@@ -1,0 +1,58 @@
+use crate::commands::project::{new_project_impl, open_project_impl};
+use crate::state::{current_crypto_key, CryptoState, CryptoStateHandle, DbState};
+use std::path::PathBuf;
+use std::sync::Mutex;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn crypto_state_with_key() -> CryptoStateHandle {
+    Mutex::new(CryptoState {
+        key: Some([7u8; 32]),
+        salt: Some(vec![1, 2, 3]),
+    })
+}
+
+fn unique_temp_dir(label: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    std::env::temp_dir().join(format!(
+        "school_record_app_{label}_{}_{}",
+        std::process::id(),
+        nanos
+    ))
+}
+
+#[test]
+fn test_new_project_clears_crypto_state() {
+    let dir = unique_temp_dir("new_project");
+    std::fs::create_dir(&dir).unwrap();
+    let path = dir.join("new.db");
+    let db = DbState(Mutex::new(None));
+    let crypto = crypto_state_with_key();
+
+    new_project_impl(path.to_str().unwrap(), &db, &crypto).unwrap();
+
+    assert!(db.0.lock().unwrap().is_some());
+    assert!(current_crypto_key(&crypto).unwrap().is_none());
+
+    std::fs::remove_dir_all(&dir).unwrap();
+}
+
+#[test]
+fn test_open_project_clears_crypto_state() {
+    let dir = unique_temp_dir("open_project");
+    std::fs::create_dir(&dir).unwrap();
+    let path = dir.join("existing.db");
+    drop(crate::db::create_new(&path).unwrap());
+
+    let db = DbState(Mutex::new(None));
+    let crypto = crypto_state_with_key();
+
+    open_project_impl(path.to_str().unwrap(), &db, &crypto).unwrap();
+
+    assert!(db.0.lock().unwrap().is_some());
+    assert!(current_crypto_key(&crypto).unwrap().is_none());
+
+    std::fs::remove_dir_all(&dir).unwrap();
+}

--- a/src-tauri/src/tests/record_tests.rs
+++ b/src-tauri/src/tests/record_tests.rs
@@ -13,7 +13,7 @@ fn test_upsert_record_creates_new() {
     let act_id = insert_activity(&conn, "발표");
     let stu_id = insert_student(&conn, 1, 1, 1, "홍길동");
 
-    upsert_record_impl(&conn, act_id, stu_id, "훌륭한 발표").unwrap();
+    upsert_record_impl(&conn, act_id, stu_id, "훌륭한 발표", None).unwrap();
 
     let content: String = conn
         .query_row(
@@ -31,8 +31,8 @@ fn test_upsert_record_updates_existing() {
     let act_id = insert_activity(&conn, "발표");
     let stu_id = insert_student(&conn, 1, 1, 1, "홍길동");
 
-    upsert_record_impl(&conn, act_id, stu_id, "초기 내용").unwrap();
-    upsert_record_impl(&conn, act_id, stu_id, "수정된 내용").unwrap();
+    upsert_record_impl(&conn, act_id, stu_id, "초기 내용", None).unwrap();
+    upsert_record_impl(&conn, act_id, stu_id, "수정된 내용", None).unwrap();
 
     let content: String = conn
         .query_row(
@@ -68,9 +68,9 @@ fn test_get_area_grid_activities_and_students() {
         rusqlite::params![area_id, stu_id],
     )
     .unwrap();
-    upsert_record_impl(&conn, act_id, stu_id, "독후감").unwrap();
+    upsert_record_impl(&conn, act_id, stu_id, "독후감", None).unwrap();
 
-    let grid = get_area_grid_impl(&conn, area_id).unwrap();
+    let grid = get_area_grid_impl(&conn, area_id, None).unwrap();
     assert_eq!(grid.activities.len(), 1);
     assert_eq!(grid.activities[0].name, "독서");
     assert_eq!(grid.students.len(), 1);
@@ -84,7 +84,7 @@ fn test_get_area_grid_empty_returns_empty_records() {
     let conn = setup_test_db();
     let area_id = insert_area(&conn, "수학", 300);
 
-    let grid = get_area_grid_impl(&conn, area_id).unwrap();
+    let grid = get_area_grid_impl(&conn, area_id, None).unwrap();
     assert!(grid.activities.is_empty());
     assert!(grid.students.is_empty());
     assert!(grid.records.is_empty());
@@ -101,7 +101,7 @@ fn test_get_area_grid_activities_only_empty_records() {
     )
     .unwrap();
 
-    let grid = get_area_grid_impl(&conn, area_id).unwrap();
+    let grid = get_area_grid_impl(&conn, area_id, None).unwrap();
 
     assert_eq!(grid.activities.len(), 1);
     assert_eq!(grid.activities[0].name, "독서");
@@ -123,7 +123,7 @@ fn test_get_area_grid_activities_sorted_by_name() {
         .unwrap();
     }
 
-    let grid = get_area_grid_impl(&conn, area_id).unwrap();
+    let grid = get_area_grid_impl(&conn, area_id, None).unwrap();
 
     assert_eq!(grid.activities.len(), 2);
     assert_eq!(grid.activities[0].name, "A발표");
@@ -145,7 +145,7 @@ fn test_get_area_grid_students_sorted() {
         .unwrap();
     }
 
-    let grid = get_area_grid_impl(&conn, area_id).unwrap();
+    let grid = get_area_grid_impl(&conn, area_id, None).unwrap();
 
     assert_eq!(grid.students.len(), 3);
     assert_eq!(grid.students[0].name, "가학생"); // (1,1,2)
@@ -161,7 +161,7 @@ fn test_get_record_history_empty() {
     let act_id = insert_activity(&conn, "발표");
     let stu_id = insert_student(&conn, 1, 1, 1, "홍길동");
 
-    let entries = get_record_history_impl(&conn, act_id, stu_id, 10, 0).unwrap();
+    let entries = get_record_history_impl(&conn, act_id, stu_id, 10, 0, None).unwrap();
     assert!(entries.is_empty());
 }
 
@@ -171,7 +171,7 @@ fn test_get_record_history_ordered_desc() {
     let act_id = insert_activity(&conn, "발표");
     let stu_id = insert_student(&conn, 1, 1, 1, "홍길동");
 
-    upsert_record_impl(&conn, act_id, stu_id, "첫 번째").unwrap();
+    upsert_record_impl(&conn, act_id, stu_id, "첫 번째", None).unwrap();
     conn.execute(
         "INSERT INTO ActivityRecordHistory (activity_record_id, content, changed_at, note)
          SELECT id, content, '2024-01-01 10:00:00', NULL FROM ActivityRecord
@@ -187,7 +187,7 @@ fn test_get_record_history_ordered_desc() {
     )
     .unwrap();
 
-    let entries = get_record_history_impl(&conn, act_id, stu_id, 10, 0).unwrap();
+    let entries = get_record_history_impl(&conn, act_id, stu_id, 10, 0, None).unwrap();
     assert_eq!(entries.len(), 2);
     assert!(entries[0].changed_at > entries[1].changed_at, "최신 항목이 먼저여야 한다");
 }
@@ -198,7 +198,7 @@ fn test_get_record_history_limit_offset() {
     let act_id = insert_activity(&conn, "발표");
     let stu_id = insert_student(&conn, 1, 1, 1, "홍길동");
 
-    upsert_record_impl(&conn, act_id, stu_id, "내용").unwrap();
+    upsert_record_impl(&conn, act_id, stu_id, "내용", None).unwrap();
     for ts in &["2024-01-01 10:00:00", "2024-01-02 10:00:00", "2024-01-03 10:00:00"] {
         conn.execute(
             "INSERT INTO ActivityRecordHistory (activity_record_id, content, changed_at, note)
@@ -209,8 +209,8 @@ fn test_get_record_history_limit_offset() {
         .unwrap();
     }
 
-    let page1 = get_record_history_impl(&conn, act_id, stu_id, 1, 0).unwrap();
-    let page2 = get_record_history_impl(&conn, act_id, stu_id, 1, 1).unwrap();
+    let page1 = get_record_history_impl(&conn, act_id, stu_id, 1, 0, None).unwrap();
+    let page2 = get_record_history_impl(&conn, act_id, stu_id, 1, 1, None).unwrap();
     assert_eq!(page1.len(), 1);
     assert_eq!(page2.len(), 1);
     assert_ne!(page1[0].id, page2[0].id);
@@ -222,7 +222,7 @@ fn test_get_record_history_note_optional() {
     let act_id = insert_activity(&conn, "발표");
     let stu_id = insert_student(&conn, 1, 1, 1, "홍길동");
 
-    upsert_record_impl(&conn, act_id, stu_id, "내용").unwrap();
+    upsert_record_impl(&conn, act_id, stu_id, "내용", None).unwrap();
     conn.execute(
         "INSERT INTO ActivityRecordHistory (activity_record_id, content, changed_at, note)
          SELECT id, content, '2024-01-01 10:00:00', 'snapshot' FROM ActivityRecord
@@ -238,7 +238,7 @@ fn test_get_record_history_note_optional() {
     )
     .unwrap();
 
-    let entries = get_record_history_impl(&conn, act_id, stu_id, 10, 0).unwrap();
+    let entries = get_record_history_impl(&conn, act_id, stu_id, 10, 0, None).unwrap();
     assert_eq!(entries.len(), 2);
     let notes: Vec<Option<String>> = entries.iter().map(|e| e.note.clone()).collect();
     assert!(notes.iter().any(|n| n.is_some()), "note=Some 항목이 있어야 한다");
@@ -253,7 +253,7 @@ fn test_save_snapshot_creates_history_entry() {
     let act_id = insert_activity(&conn, "발표");
     let stu_id = insert_student(&conn, 1, 1, 1, "홍길동");
 
-    upsert_record_impl(&conn, act_id, stu_id, "발표 내용").unwrap();
+    upsert_record_impl(&conn, act_id, stu_id, "발표 내용", None).unwrap();
     save_snapshot_internal(&conn, act_id, stu_id, Some("스냅샷")).unwrap();
 
     let count: i64 = conn
@@ -274,7 +274,7 @@ fn test_save_snapshot_no_duplicate_same_updated_at() {
     let act_id = insert_activity(&conn, "발표");
     let stu_id = insert_student(&conn, 1, 1, 1, "홍길동");
 
-    upsert_record_impl(&conn, act_id, stu_id, "발표 내용").unwrap();
+    upsert_record_impl(&conn, act_id, stu_id, "발표 내용", None).unwrap();
     save_snapshot_internal(&conn, act_id, stu_id, None).unwrap();
     save_snapshot_internal(&conn, act_id, stu_id, None).unwrap();
 
@@ -296,7 +296,7 @@ fn test_save_snapshot_updates_note_when_exists() {
     let act_id = insert_activity(&conn, "발표");
     let stu_id = insert_student(&conn, 1, 1, 1, "홍길동");
 
-    upsert_record_impl(&conn, act_id, stu_id, "발표 내용").unwrap();
+    upsert_record_impl(&conn, act_id, stu_id, "발표 내용", None).unwrap();
     save_snapshot_internal(&conn, act_id, stu_id, Some("초기 노트")).unwrap();
     save_snapshot_internal(&conn, act_id, stu_id, Some("수정 노트")).unwrap();
 
@@ -346,7 +346,7 @@ fn test_bulk_import_creates_new_student() {
     let conn = setup_test_db();
     let act_id = insert_activity(&conn, "발표");
 
-    bulk_import_records_impl(&conn, &[make_import(1, 1, 1, Some("홍길동"), act_id, "내용")]).unwrap();
+    bulk_import_records_impl(&conn, &[make_import(1, 1, 1, Some("홍길동"), act_id, "내용")], None).unwrap();
 
     let count: i64 = conn
         .query_row("SELECT COUNT(*) FROM Student", [], |row| row.get(0))
@@ -360,7 +360,7 @@ fn test_bulk_import_updates_name_when_existing_is_blank() {
     let act_id = insert_activity(&conn, "발표");
     insert_student(&conn, 1, 1, 1, "");
 
-    bulk_import_records_impl(&conn, &[make_import(1, 1, 1, Some("홍길동"), act_id, "내용")]).unwrap();
+    bulk_import_records_impl(&conn, &[make_import(1, 1, 1, Some("홍길동"), act_id, "내용")], None).unwrap();
 
     let name: String = conn
         .query_row(
@@ -378,7 +378,7 @@ fn test_bulk_import_skips_name_update_when_existing_nonempty() {
     let act_id = insert_activity(&conn, "발표");
     insert_student(&conn, 1, 1, 1, "기존이름");
 
-    bulk_import_records_impl(&conn, &[make_import(1, 1, 1, Some("새이름"), act_id, "내용")]).unwrap();
+    bulk_import_records_impl(&conn, &[make_import(1, 1, 1, Some("새이름"), act_id, "내용")], None).unwrap();
 
     let name: String = conn
         .query_row(
@@ -395,8 +395,8 @@ fn test_bulk_import_upserts_record() {
     let conn = setup_test_db();
     let act_id = insert_activity(&conn, "발표");
 
-    bulk_import_records_impl(&conn, &[make_import(1, 1, 1, Some("홍길동"), act_id, "처음")]).unwrap();
-    bulk_import_records_impl(&conn, &[make_import(1, 1, 1, Some("홍길동"), act_id, "갱신")]).unwrap();
+    bulk_import_records_impl(&conn, &[make_import(1, 1, 1, Some("홍길동"), act_id, "처음")], None).unwrap();
+    bulk_import_records_impl(&conn, &[make_import(1, 1, 1, Some("홍길동"), act_id, "갱신")], None).unwrap();
 
     let content: String = conn
         .query_row(
@@ -418,7 +418,7 @@ fn test_bulk_import_creates_history_for_nonempty_content() {
     let conn = setup_test_db();
     let act_id = insert_activity(&conn, "발표");
 
-    bulk_import_records_impl(&conn, &[make_import(1, 1, 1, Some("홍길동"), act_id, "내용")]).unwrap();
+    bulk_import_records_impl(&conn, &[make_import(1, 1, 1, Some("홍길동"), act_id, "내용")], None).unwrap();
 
     let count: i64 = conn
         .query_row("SELECT COUNT(*) FROM ActivityRecordHistory", [], |row| row.get(0))
@@ -431,7 +431,7 @@ fn test_bulk_import_no_history_for_empty_content() {
     let conn = setup_test_db();
     let act_id = insert_activity(&conn, "발표");
 
-    bulk_import_records_impl(&conn, &[make_import(1, 1, 1, Some("홍길동"), act_id, "")]).unwrap();
+    bulk_import_records_impl(&conn, &[make_import(1, 1, 1, Some("홍길동"), act_id, "")], None).unwrap();
 
     let count: i64 = conn
         .query_row("SELECT COUNT(*) FROM ActivityRecordHistory", [], |row| row.get(0))
@@ -451,6 +451,7 @@ fn test_bulk_import_student_cache_deduplication() {
             make_import(1, 1, 1, Some("홍길동"), act_id1, "내용1"),
             make_import(1, 1, 1, Some("홍길동"), act_id2, "내용2"),
         ],
+        None,
     )
     .unwrap();
 
@@ -473,6 +474,7 @@ fn test_bulk_import_result_counts() {
             make_import(1, 1, 2, Some("신규2"), act_id, "내용B"),
             make_import(2, 1, 1, Some("기존학생"), act_id, "내용C"),
         ],
+        None,
     )
     .unwrap();
 
@@ -486,7 +488,7 @@ fn test_bulk_import_uses_default_name_when_none() {
     let conn = setup_test_db();
     let act_id = insert_activity(&conn, "발표");
 
-    bulk_import_records_impl(&conn, &[make_import(1, 1, 1, None, act_id, "내용")]).unwrap();
+    bulk_import_records_impl(&conn, &[make_import(1, 1, 1, None, act_id, "내용")], None).unwrap();
 
     let name: String = conn
         .query_row(
@@ -510,6 +512,7 @@ fn test_preview_existing_student_shows_existing_content() {
     let items = preview_import_records_impl(
         &conn,
         &[make_import(1, 1, 1, Some("홍길동"), act_id, "새 내용")],
+        None,
     )
     .unwrap();
 
@@ -526,6 +529,7 @@ fn test_preview_new_student_shows_empty_existing_content() {
     let items = preview_import_records_impl(
         &conn,
         &[make_import(1, 1, 99, Some("신규학생"), act_id, "새 내용")],
+        None,
     )
     .unwrap();
 
@@ -542,6 +546,7 @@ fn test_preview_activity_name_fallback() {
     let items = preview_import_records_impl(
         &conn,
         &[make_import(1, 1, 1, Some("홍길동"), fake_act_id, "내용")],
+        None,
     )
     .unwrap();
 
@@ -555,7 +560,7 @@ fn test_preview_activity_name_fallback() {
 fn test_bulk_import_empty_input_returns_zeros() {
     let conn = setup_test_db();
 
-    let result = bulk_import_records_impl(&conn, &[]).unwrap();
+    let result = bulk_import_records_impl(&conn, &[], None).unwrap();
 
     assert_eq!(result.students_created, 0);
     assert_eq!(result.students_updated, 0);
@@ -566,7 +571,7 @@ fn test_bulk_import_empty_input_returns_zeros() {
 fn test_preview_import_empty_input_returns_empty() {
     let conn = setup_test_db();
 
-    let items = preview_import_records_impl(&conn, &[]).unwrap();
+    let items = preview_import_records_impl(&conn, &[], None).unwrap();
 
     assert!(items.is_empty());
 }
@@ -585,7 +590,7 @@ fn test_bulk_import_rollback_on_fk_violation() {
     ];
 
     conn.execute_batch("BEGIN").unwrap();
-    let result = bulk_import_records_impl(&conn, &records);
+    let result = bulk_import_records_impl(&conn, &records, None);
     match result {
         Ok(_) => { conn.execute_batch("COMMIT").unwrap(); }
         Err(_) => { let _ = conn.execute_batch("ROLLBACK"); }
@@ -616,6 +621,7 @@ fn test_bulk_import_same_student_multiple_activities_records_saved() {
             make_import(1, 1, 1, Some("홍길동"), act_id1, "독서 내용"),
             make_import(1, 1, 1, Some("홍길동"), act_id2, "발표 내용"),
         ],
+        None,
     )
     .unwrap();
 

--- a/src-tauri/src/tests/replace_tests.rs
+++ b/src-tauri/src/tests/replace_tests.rs
@@ -195,7 +195,7 @@ fn test_preview_replace_with_regex() {
     create_replace_rule_db(&conn, r"\n+", " ", true, 0).unwrap();
 
     let rules = fetch_rules_from_db(&conn).unwrap();
-    let records = get_records_for_scope(&conn, "all", &[]).unwrap();
+    let records = get_records_for_scope(&conn, "all", &[], None).unwrap();
     assert_eq!(records.len(), 1);
     let result = apply_rules(&records[0].content, &rules);
     assert!(!result.contains('\n'), "정규식 규칙 적용 후 개행 없어야 함: {:?}", result);

--- a/src-tauri/src/tests/snapshot_tests.rs
+++ b/src-tauri/src/tests/snapshot_tests.rs
@@ -9,7 +9,7 @@ fn test_create_snapshot_creates_history_for_records() {
     let conn = setup_test_db();
     let act_id = insert_activity(&conn, "발표");
     let stu_id = insert_student(&conn, 1, 1, 1, "홍길동");
-    upsert_record_impl(&conn, act_id, stu_id, "훌륭한 발표").unwrap();
+    upsert_record_impl(&conn, act_id, stu_id, "훌륭한 발표", None).unwrap();
 
     create_snapshot_impl(&conn, None).unwrap();
 
@@ -24,7 +24,7 @@ fn test_create_snapshot_no_duplicate_same_updated_at() {
     let conn = setup_test_db();
     let act_id = insert_activity(&conn, "발표");
     let stu_id = insert_student(&conn, 1, 1, 1, "홍길동");
-    upsert_record_impl(&conn, act_id, stu_id, "내용").unwrap();
+    upsert_record_impl(&conn, act_id, stu_id, "내용", None).unwrap();
 
     create_snapshot_impl(&conn, None).unwrap();
     create_snapshot_impl(&conn, None).unwrap();
@@ -110,11 +110,11 @@ fn test_restore_snapshot_reverts_content() {
     let conn = setup_test_db();
     let act_id = insert_activity(&conn, "발표");
     let stu_id = insert_student(&conn, 1, 1, 1, "홍길동");
-    upsert_record_impl(&conn, act_id, stu_id, "초기 내용").unwrap();
+    upsert_record_impl(&conn, act_id, stu_id, "초기 내용", None).unwrap();
 
     let snap = create_snapshot_impl(&conn, None).unwrap();
 
-    upsert_record_impl(&conn, act_id, stu_id, "수정된 내용").unwrap();
+    upsert_record_impl(&conn, act_id, stu_id, "수정된 내용", None).unwrap();
 
     restore_snapshot_impl(&conn, snap.id).unwrap();
 
@@ -170,8 +170,8 @@ fn test_restore_returns_affected_row_count() {
     let act_id = insert_activity(&conn, "발표");
     let stu1 = insert_student(&conn, 1, 1, 1, "홍길동");
     let stu2 = insert_student(&conn, 1, 1, 2, "김철수");
-    upsert_record_impl(&conn, act_id, stu1, "내용1").unwrap();
-    upsert_record_impl(&conn, act_id, stu2, "내용2").unwrap();
+    upsert_record_impl(&conn, act_id, stu1, "내용1", None).unwrap();
+    upsert_record_impl(&conn, act_id, stu2, "내용2", None).unwrap();
 
     let snap = create_snapshot_impl(&conn, None).unwrap();
     let count = restore_snapshot_impl(&conn, snap.id).unwrap();

--- a/src-tauri/src/tests/student_tests.rs
+++ b/src-tauri/src/tests/student_tests.rs
@@ -8,15 +8,15 @@ use super::{insert_activity, insert_area, insert_record, insert_student, setup_t
 #[test]
 fn test_create_student_returns_id() {
     let conn = setup_test_db();
-    let id = create_student_impl(&conn, 1, 1, 1, "홍길동").unwrap();
+    let id = create_student_impl(&conn, 1, 1, 1, "홍길동", None).unwrap();
     assert!(id > 0);
 }
 
 #[test]
 fn test_create_student_duplicate_key_error() {
     let conn = setup_test_db();
-    create_student_impl(&conn, 1, 1, 1, "홍길동").unwrap();
-    let err = create_student_impl(&conn, 1, 1, 1, "홍길동").unwrap_err();
+    create_student_impl(&conn, 1, 1, 1, "홍길동", None).unwrap();
+    let err = create_student_impl(&conn, 1, 1, 1, "홍길동", None).unwrap_err();
     assert!(err.contains("이미 같은 학번의 학생"), "에러 메시지: {err}");
 }
 
@@ -27,7 +27,7 @@ fn test_get_students_ordered_by_grade_class_number() {
     insert_student(&conn, 1, 2, 1, "나");
     insert_student(&conn, 1, 1, 5, "가");
 
-    let students = get_students_impl(&conn).unwrap();
+    let students = get_students_impl(&conn, None).unwrap();
     assert_eq!(students[0].name, "가");
     assert_eq!(students[1].name, "나");
     assert_eq!(students[2].name, "다");
@@ -36,10 +36,10 @@ fn test_get_students_ordered_by_grade_class_number() {
 #[test]
 fn test_update_student() {
     let conn = setup_test_db();
-    let id = create_student_impl(&conn, 1, 1, 1, "홍길동").unwrap();
-    update_student_impl(&conn, id, 2, 3, 10, "김철수").unwrap();
+    let id = create_student_impl(&conn, 1, 1, 1, "홍길동", None).unwrap();
+    update_student_impl(&conn, id, 2, 3, 10, "김철수", None).unwrap();
 
-    let students = get_students_impl(&conn).unwrap();
+    let students = get_students_impl(&conn, None).unwrap();
     assert_eq!(students[0].name, "김철수");
     assert_eq!(students[0].grade, 2);
     assert_eq!(students[0].class_num, 3);
@@ -49,20 +49,20 @@ fn test_update_student() {
 #[test]
 fn test_update_student_duplicate_key_error() {
     let conn = setup_test_db();
-    let id1 = create_student_impl(&conn, 1, 1, 1, "홍길동").unwrap();
-    let id2 = create_student_impl(&conn, 1, 1, 2, "김철수").unwrap();
+    let id1 = create_student_impl(&conn, 1, 1, 1, "홍길동", None).unwrap();
+    let id2 = create_student_impl(&conn, 1, 1, 2, "김철수", None).unwrap();
     let _ = id1;
-    let err = update_student_impl(&conn, id2, 1, 1, 1, "김철수").unwrap_err();
+    let err = update_student_impl(&conn, id2, 1, 1, 1, "김철수", None).unwrap_err();
     assert!(err.contains("이미 같은 학번의 학생"), "에러 메시지: {err}");
 }
 
 #[test]
 fn test_delete_student() {
     let conn = setup_test_db();
-    let id = create_student_impl(&conn, 1, 1, 1, "홍길동").unwrap();
+    let id = create_student_impl(&conn, 1, 1, 1, "홍길동", None).unwrap();
     delete_student_impl(&conn, id).unwrap();
 
-    let students = get_students_impl(&conn).unwrap();
+    let students = get_students_impl(&conn, None).unwrap();
     assert!(students.is_empty());
 }
 
@@ -92,7 +92,7 @@ fn test_bulk_upsert_all_new() {
         StudentInput { grade: 1, class_num: 1, number: 1, name: "가".to_string() },
         StudentInput { grade: 1, class_num: 1, number: 2, name: "나".to_string() },
     ];
-    let result = bulk_upsert_students_impl(&conn, &students).unwrap();
+    let result = bulk_upsert_students_impl(&conn, &students, None).unwrap();
     assert_eq!(result.inserted, 2);
     assert_eq!(result.updated, 0);
 }
@@ -107,11 +107,11 @@ fn test_bulk_upsert_all_existing() {
         StudentInput { grade: 1, class_num: 1, number: 1, name: "홍길동(변경)".to_string() },
         StudentInput { grade: 1, class_num: 1, number: 2, name: "김철수(변경)".to_string() },
     ];
-    let result = bulk_upsert_students_impl(&conn, &students).unwrap();
+    let result = bulk_upsert_students_impl(&conn, &students, None).unwrap();
     assert_eq!(result.inserted, 0);
     assert_eq!(result.updated, 2);
 
-    let list = get_students_impl(&conn).unwrap();
+    let list = get_students_impl(&conn, None).unwrap();
     assert_eq!(list[0].name, "홍길동(변경)");
     assert_eq!(list[1].name, "김철수(변경)");
 }
@@ -125,7 +125,7 @@ fn test_bulk_upsert_mixed() {
         StudentInput { grade: 1, class_num: 1, number: 1, name: "기존(갱신)".to_string() },
         StudentInput { grade: 1, class_num: 1, number: 2, name: "신규".to_string() },
     ];
-    let result = bulk_upsert_students_impl(&conn, &students).unwrap();
+    let result = bulk_upsert_students_impl(&conn, &students, None).unwrap();
     assert_eq!(result.inserted, 1);
     assert_eq!(result.updated, 1);
 }
@@ -133,7 +133,7 @@ fn test_bulk_upsert_mixed() {
 #[test]
 fn test_bulk_upsert_empty_list() {
     let conn = setup_test_db();
-    let result = bulk_upsert_students_impl(&conn, &[]).unwrap();
+    let result = bulk_upsert_students_impl(&conn, &[], None).unwrap();
     assert_eq!(result.inserted, 0);
     assert_eq!(result.updated, 0);
 }
@@ -269,7 +269,7 @@ fn test_delete_student_cascades_area_student() {
 #[test]
 fn test_get_students_empty() {
     let conn = setup_test_db();
-    let students = get_students_impl(&conn).unwrap();
+    let students = get_students_impl(&conn, None).unwrap();
     assert!(students.is_empty());
 }
 
@@ -278,28 +278,28 @@ fn test_get_students_empty() {
 #[test]
 fn test_create_student_grade_zero_violates_check() {
     let conn = setup_test_db();
-    let err = create_student_impl(&conn, 0, 1, 1, "홍길동").unwrap_err();
+    let err = create_student_impl(&conn, 0, 1, 1, "홍길동", None).unwrap_err();
     assert!(err.contains("CHECK constraint failed"), "grade=0 CHECK 위반이어야 함: {err}");
 }
 
 #[test]
 fn test_create_student_class_num_zero_violates_check() {
     let conn = setup_test_db();
-    let err = create_student_impl(&conn, 1, 0, 1, "홍길동").unwrap_err();
+    let err = create_student_impl(&conn, 1, 0, 1, "홍길동", None).unwrap_err();
     assert!(err.contains("CHECK constraint failed"), "class_num=0 CHECK 위반이어야 함: {err}");
 }
 
 #[test]
 fn test_create_student_number_zero_violates_check() {
     let conn = setup_test_db();
-    let err = create_student_impl(&conn, 1, 1, 0, "홍길동").unwrap_err();
+    let err = create_student_impl(&conn, 1, 1, 0, "홍길동", None).unwrap_err();
     assert!(err.contains("CHECK constraint failed"), "number=0 CHECK 위반이어야 함: {err}");
 }
 
 #[test]
 fn test_update_student_negative_grade_violates_check() {
     let conn = setup_test_db();
-    let id = create_student_impl(&conn, 1, 1, 1, "홍길동").unwrap();
-    let err = update_student_impl(&conn, id, -1, 1, 1, "홍길동").unwrap_err();
+    let id = create_student_impl(&conn, 1, 1, 1, "홍길동", None).unwrap();
+    let err = update_student_impl(&conn, id, -1, 1, 1, "홍길동", None).unwrap_err();
     assert!(err.contains("CHECK constraint failed"), "grade=-1 CHECK 위반이어야 함: {err}");
 }

--- a/src-tauri/src/tests/synonym_tests.rs
+++ b/src-tauri/src/tests/synonym_tests.rs
@@ -184,7 +184,7 @@ fn setup_inspect_db() -> rusqlite::Connection {
 #[test]
 fn test_get_all_records_for_inspect_all_scope() {
     let conn = setup_inspect_db();
-    let records = get_all_records_for_inspect_impl(&conn, "all", vec![]).unwrap();
+    let records = get_all_records_for_inspect_impl(&conn, "all", vec![], None).unwrap();
     assert_eq!(records.len(), 1);
     assert_eq!(records[0].content, "테스트 기록");
     assert_eq!(records[0].student_name, "홍길동");
@@ -197,7 +197,7 @@ fn test_get_all_records_for_inspect_areas_scope() {
         .query_row("SELECT id FROM Area WHERE name = '영역A'", [], |r| r.get(0))
         .unwrap();
 
-    let records = get_all_records_for_inspect_impl(&conn, "areas", vec![area_id]).unwrap();
+    let records = get_all_records_for_inspect_impl(&conn, "areas", vec![area_id], None).unwrap();
     assert_eq!(records.len(), 1);
     assert_eq!(records[0].area_name, "영역A");
 }
@@ -205,14 +205,14 @@ fn test_get_all_records_for_inspect_areas_scope() {
 #[test]
 fn test_get_all_records_for_inspect_areas_empty_ids() {
     let conn = setup_inspect_db();
-    let records = get_all_records_for_inspect_impl(&conn, "areas", vec![]).unwrap();
+    let records = get_all_records_for_inspect_impl(&conn, "areas", vec![], None).unwrap();
     assert!(records.is_empty(), "area_ids=[] 이면 빈 목록 반환");
 }
 
 #[test]
 fn test_get_all_records_for_inspect_unknown_scope_error() {
     let conn = setup_test_db();
-    let err = get_all_records_for_inspect_impl(&conn, "unknown", vec![]).unwrap_err();
+    let err = get_all_records_for_inspect_impl(&conn, "unknown", vec![], None).unwrap_err();
     assert!(err.contains("알 수 없는 scope_type"), "에러 메시지: {err}");
 }
 
@@ -240,7 +240,7 @@ fn test_inspect_multiple_area_ids() {
     conn.execute("INSERT INTO ActivityRecord (activity_id, student_id, content) VALUES (?1, ?2, '기록1')", rusqlite::params![act1, stu]).unwrap();
     conn.execute("INSERT INTO ActivityRecord (activity_id, student_id, content) VALUES (?1, ?2, '기록2')", rusqlite::params![act2, stu]).unwrap();
 
-    let records = get_all_records_for_inspect_impl(&conn, "areas", vec![area1, area2]).unwrap();
+    let records = get_all_records_for_inspect_impl(&conn, "areas", vec![area1, area2], None).unwrap();
     assert_eq!(records.len(), 2, "두 area_id로 조회 시 2개 기록 반환: {:?}", records);
 }
 
@@ -264,7 +264,7 @@ fn test_inspect_area_student_filter() {
     conn.execute("INSERT INTO ActivityRecord (activity_id, student_id, content) VALUES (?1, ?2, '기록1')", rusqlite::params![act, stu1]).unwrap();
     conn.execute("INSERT INTO ActivityRecord (activity_id, student_id, content) VALUES (?1, ?2, '기록2')", rusqlite::params![act, stu2]).unwrap();
 
-    let records = get_all_records_for_inspect_impl(&conn, "areas", vec![area]).unwrap();
+    let records = get_all_records_for_inspect_impl(&conn, "areas", vec![area], None).unwrap();
     assert_eq!(records.len(), 1, "AreaStudent 미등록 학생 기록은 제외되어야 함");
     assert_eq!(records[0].student_name, "등록학생");
 }
@@ -280,7 +280,7 @@ fn test_inspect_coalesce_null_area_name() {
     let stu = conn.last_insert_rowid();
     conn.execute("INSERT INTO ActivityRecord (activity_id, student_id, content) VALUES (?1, ?2, '독립기록')", rusqlite::params![act, stu]).unwrap();
 
-    let records = get_all_records_for_inspect_impl(&conn, "all", vec![]).unwrap();
+    let records = get_all_records_for_inspect_impl(&conn, "all", vec![], None).unwrap();
     assert_eq!(records.len(), 1);
     assert_eq!(records[0].area_name, "", "area 미연결 기록은 area_name='' 이어야 함");
     assert_eq!(records[0].student_name, "독립학생");
@@ -302,6 +302,6 @@ fn test_get_all_records_for_inspect_excludes_empty_content() {
         rusqlite::params![act_id, stu_id],
     ).unwrap();
 
-    let records = get_all_records_for_inspect_impl(&conn, "all", vec![]).unwrap();
+    let records = get_all_records_for_inspect_impl(&conn, "all", vec![], None).unwrap();
     assert!(records.is_empty(), "content='' 기록은 제외되어야 함");
 }

--- a/src/components/PasswordModal.vue
+++ b/src/components/PasswordModal.vue
@@ -1,0 +1,385 @@
+<script setup>
+import { ref, computed, watch } from 'vue'
+import { Lock, Eye, EyeOff, AlertTriangle } from 'lucide-vue-next'
+
+const props = defineProps({
+  // 'unlock' | 'setup' | 'change'
+  mode: { type: String, required: true },
+  error: { type: String, default: '' },
+  loading: { type: Boolean, default: false },
+})
+
+const emit = defineEmits(['submit', 'cancel'])
+
+const password = ref('')
+const newPassword = ref('')
+const confirmPassword = ref('')
+const showPassword = ref(false)
+const showNewPassword = ref(false)
+const localError = ref('')
+
+const title = computed(() => {
+  if (props.mode === 'unlock') return '비밀번호 확인'
+  if (props.mode === 'setup') return '암호화 비밀번호 설정'
+  return '비밀번호 변경'
+})
+
+const submitLabel = computed(() => {
+  if (props.mode === 'unlock') return '잠금 해제'
+  if (props.mode === 'setup') return '암호화 활성화'
+  return '비밀번호 변경'
+})
+
+watch(() => props.error, (val) => {
+  if (val) localError.value = val
+})
+
+function validate() {
+  localError.value = ''
+  if (!password.value) {
+    localError.value = '비밀번호를 입력해주세요.'
+    return false
+  }
+  if (props.mode === 'setup' || props.mode === 'change') {
+    if (props.mode === 'change' && !newPassword.value) {
+      localError.value = '새 비밀번호를 입력해주세요.'
+      return false
+    }
+    const target = props.mode === 'setup' ? newPassword.value || password.value : newPassword.value
+    const confirm = confirmPassword.value
+    if (props.mode === 'setup') {
+      if (!password.value) {
+        localError.value = '비밀번호를 입력해주세요.'
+        return false
+      }
+      if (password.value !== confirmPassword.value) {
+        localError.value = '비밀번호와 확인 비밀번호가 일치하지 않습니다.'
+        return false
+      }
+    } else {
+      if (newPassword.value !== confirmPassword.value) {
+        localError.value = '새 비밀번호와 확인 비밀번호가 일치하지 않습니다.'
+        return false
+      }
+    }
+  }
+  return true
+}
+
+function handleSubmit() {
+  if (!validate()) return
+  if (props.mode === 'unlock') {
+    emit('submit', { password: password.value })
+  } else if (props.mode === 'setup') {
+    emit('submit', { password: password.value })
+  } else {
+    emit('submit', { oldPassword: password.value, newPassword: newPassword.value })
+  }
+}
+
+function handleCancel() {
+  emit('cancel')
+}
+</script>
+
+<template>
+  <div class="overlay">
+    <div class="modal">
+      <div class="modal-header">
+        <div class="header-icon">
+          <Lock :size="20"/>
+        </div>
+        <div>
+          <h2>{{ title }}</h2>
+          <p v-if="mode === 'unlock'">이 파일은 암호화되어 있습니다.</p>
+          <p v-else-if="mode === 'setup'">암호화할 비밀번호를 설정합니다.</p>
+          <p v-else>현재 비밀번호와 새 비밀번호를 입력합니다.</p>
+        </div>
+      </div>
+
+      <!-- 비밀번호 분실 경고 (setup 모드) -->
+      <div v-if="mode === 'setup'" class="warning-box">
+        <AlertTriangle :size="16" class="warning-icon"/>
+        <span>비밀번호를 분실하면 데이터를 복구할 수 없습니다. 반드시 안전한 곳에 보관하세요.</span>
+      </div>
+
+      <div class="form">
+        <!-- 현재/기존 비밀번호 -->
+        <div class="field">
+          <label>{{ mode === 'change' ? '현재 비밀번호' : '비밀번호' }}</label>
+          <div class="input-wrap">
+            <input
+              :type="showPassword ? 'text' : 'password'"
+              v-model="password"
+              :placeholder="mode === 'change' ? '현재 비밀번호' : '비밀번호 입력'"
+              @keydown.enter="handleSubmit"
+              autofocus
+            />
+            <button type="button" class="eye-btn" @click="showPassword = !showPassword">
+              <Eye v-if="!showPassword" :size="16"/>
+              <EyeOff v-else :size="16"/>
+            </button>
+          </div>
+        </div>
+
+        <!-- 새 비밀번호 (change 모드) -->
+        <div v-if="mode === 'change'" class="field">
+          <label>새 비밀번호</label>
+          <div class="input-wrap">
+            <input
+              :type="showNewPassword ? 'text' : 'password'"
+              v-model="newPassword"
+              placeholder="새 비밀번호 입력"
+              @keydown.enter="handleSubmit"
+            />
+            <button type="button" class="eye-btn" @click="showNewPassword = !showNewPassword">
+              <Eye v-if="!showNewPassword" :size="16"/>
+              <EyeOff v-else :size="16"/>
+            </button>
+          </div>
+        </div>
+
+        <!-- 비밀번호 확인 (setup/change 모드) -->
+        <div v-if="mode === 'setup' || mode === 'change'" class="field">
+          <label>{{ mode === 'setup' ? '비밀번호 확인' : '새 비밀번호 확인' }}</label>
+          <div class="input-wrap">
+            <input
+              type="password"
+              v-model="confirmPassword"
+              :placeholder="mode === 'setup' ? '비밀번호 재입력' : '새 비밀번호 재입력'"
+              @keydown.enter="handleSubmit"
+            />
+          </div>
+        </div>
+
+        <!-- 오류 메시지 -->
+        <transition name="err">
+          <div v-if="localError" class="error-box">
+            <AlertTriangle :size="15" style="flex-shrink:0; margin-top:1px;"/>
+            {{ localError }}
+          </div>
+        </transition>
+      </div>
+
+      <div class="actions">
+        <button v-if="mode !== 'unlock'" class="btn-cancel" @click="handleCancel" :disabled="loading">
+          취소
+        </button>
+        <button class="btn-submit" @click="handleSubmit" :disabled="loading">
+          <span v-if="loading" class="spinner"/>
+          <span v-else>{{ submitLabel }}</span>
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: rgba(4, 6, 12, 0.8);
+  backdrop-filter: blur(6px);
+}
+
+.modal {
+  width: 100%;
+  max-width: 420px;
+  background-color: #0e1220;
+  border: 1px solid #1a2035;
+  border-radius: 20px;
+  padding: 32px;
+  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.7);
+}
+
+.modal-header {
+  display: flex;
+  align-items: flex-start;
+  gap: 14px;
+  margin-bottom: 20px;
+}
+
+.header-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 42px;
+  height: 42px;
+  border-radius: 12px;
+  background-color: rgba(59, 91, 219, 0.15);
+  border: 1px solid rgba(59, 91, 219, 0.3);
+  color: #6ea8fe;
+  flex-shrink: 0;
+  margin-top: 2px;
+}
+
+.modal-header h2 {
+  font-size: 18px;
+  font-weight: 600;
+  color: #e2e8f0;
+  margin: 0 0 4px;
+}
+
+.modal-header p {
+  font-size: 14px;
+  color: var(--clr-text-hint);
+  margin: 0;
+}
+
+.warning-box {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 12px 14px;
+  border-radius: 10px;
+  background-color: rgba(245, 158, 11, 0.08);
+  border: 1px solid rgba(245, 158, 11, 0.25);
+  font-size: 13px;
+  color: #fbbf24;
+  line-height: 1.5;
+  margin-bottom: 18px;
+}
+
+.warning-icon {
+  flex-shrink: 0;
+  margin-top: 1px;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  margin-bottom: 22px;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.field label {
+  font-size: 13px;
+  font-weight: 500;
+  color: #94a3b8;
+}
+
+.input-wrap {
+  position: relative;
+}
+
+.input-wrap input {
+  width: 100%;
+  padding: 10px 40px 10px 14px;
+  background-color: #0b1022;
+  border: 1px solid #2e3f60;
+  border-radius: 10px;
+  color: #e2e8f0;
+  font-size: 15px;
+  outline: none;
+  transition: border-color 0.15s;
+  box-sizing: border-box;
+}
+
+.input-wrap input:focus {
+  border-color: #4c6ef5;
+}
+
+.eye-btn {
+  position: absolute;
+  right: 10px;
+  top: 50%;
+  transform: translateY(-50%);
+  background: none;
+  border: none;
+  color: var(--clr-text-hint);
+  cursor: pointer;
+  padding: 4px;
+  display: flex;
+  align-items: center;
+  transition: color 0.15s;
+}
+
+.eye-btn:hover {
+  color: #7ba3d4;
+}
+
+.error-box {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 11px 14px;
+  border-radius: 10px;
+  background-color: #2a1020;
+  border: 1px solid #4a1a28;
+  font-size: 13px;
+  color: #fca5a5;
+  line-height: 1.5;
+}
+
+.err-enter-from, .err-leave-to { opacity: 0; transform: translateY(4px); }
+.err-enter-active, .err-leave-active { transition: all 0.2s; }
+
+.actions {
+  display: flex;
+  gap: 10px;
+  justify-content: flex-end;
+}
+
+.btn-cancel {
+  padding: 10px 20px;
+  border-radius: 10px;
+  background: none;
+  border: 1px solid #2e3f60;
+  color: #94a3b8;
+  font-size: 15px;
+  cursor: pointer;
+  transition: background-color 0.15s, color 0.15s;
+}
+
+.btn-cancel:hover:not(:disabled) {
+  background-color: #1a2035;
+  color: #e2e8f0;
+}
+
+.btn-submit {
+  padding: 10px 24px;
+  border-radius: 10px;
+  background-color: #3b5bdb;
+  border: none;
+  color: #ffffff;
+  font-size: 15px;
+  font-weight: 500;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  transition: background-color 0.15s;
+  min-width: 100px;
+  justify-content: center;
+}
+
+.btn-submit:hover:not(:disabled) {
+  background-color: #4c6ef5;
+}
+
+.btn-submit:disabled, .btn-cancel:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.spinner {
+  width: 16px;
+  height: 16px;
+  border: 2px solid rgba(255, 255, 255, 0.3);
+  border-top-color: #ffffff;
+  border-radius: 50%;
+  animation: spin 0.7s linear infinite;
+}
+
+@keyframes spin { to { transform: rotate(360deg); } }
+</style>

--- a/src/components/PasswordModal.vue
+++ b/src/components/PasswordModal.vue
@@ -18,6 +18,9 @@ const showPassword = ref(false)
 const showNewPassword = ref(false)
 const localError = ref('')
 
+const isSetupMode = computed(() => props.mode === 'setup')
+const isChangeMode = computed(() => props.mode === 'change')
+
 const title = computed(() => {
   if (props.mode === 'unlock') return '비밀번호 확인'
   if (props.mode === 'setup') return '암호화 비밀번호 설정'
@@ -40,29 +43,25 @@ function validate() {
     localError.value = '비밀번호를 입력해주세요.'
     return false
   }
-  if (props.mode === 'setup' || props.mode === 'change') {
-    if (props.mode === 'change' && !newPassword.value) {
+
+  if (isSetupMode.value) {
+    if (password.value !== confirmPassword.value) {
+      localError.value = '비밀번호와 확인 비밀번호가 일치하지 않습니다.'
+      return false
+    }
+  }
+
+  if (isChangeMode.value) {
+    if (!newPassword.value) {
       localError.value = '새 비밀번호를 입력해주세요.'
       return false
     }
-    const target = props.mode === 'setup' ? newPassword.value || password.value : newPassword.value
-    const confirm = confirmPassword.value
-    if (props.mode === 'setup') {
-      if (!password.value) {
-        localError.value = '비밀번호를 입력해주세요.'
-        return false
-      }
-      if (password.value !== confirmPassword.value) {
-        localError.value = '비밀번호와 확인 비밀번호가 일치하지 않습니다.'
-        return false
-      }
-    } else {
-      if (newPassword.value !== confirmPassword.value) {
-        localError.value = '새 비밀번호와 확인 비밀번호가 일치하지 않습니다.'
-        return false
-      }
+    if (newPassword.value !== confirmPassword.value) {
+      localError.value = '새 비밀번호와 확인 비밀번호가 일치하지 않습니다.'
+      return false
     }
   }
+
   return true
 }
 

--- a/src/components/PasswordModal.vue
+++ b/src/components/PasswordModal.vue
@@ -161,8 +161,8 @@ function handleCancel() {
       </div>
 
       <div class="actions">
-        <button v-if="mode !== 'unlock'" class="btn-cancel" @click="handleCancel" :disabled="loading">
-          취소
+        <button class="btn-cancel" @click="handleCancel" :disabled="loading">
+          {{ mode === 'unlock' ? '뒤로 가기' : '취소' }}
         </button>
         <button class="btn-submit" @click="handleSubmit" :disabled="loading">
           <span v-if="loading" class="spinner"/>

--- a/src/components/PasswordModal.vue
+++ b/src/components/PasswordModal.vue
@@ -91,15 +91,15 @@ function handleCancel() {
         <div>
           <h2>{{ title }}</h2>
           <p v-if="mode === 'unlock'">이 파일은 암호화되어 있습니다.</p>
-          <p v-else-if="mode === 'setup'">암호화할 비밀번호를 설정합니다.</p>
-          <p v-else>현재 비밀번호와 새 비밀번호를 입력합니다.</p>
+          <p v-else-if="mode === 'setup'">암호화 비밀번호를 입력하세요.</p>
+          <p v-else>현재 비밀번호와 새 비밀번호를 입력하세요.</p>
         </div>
       </div>
 
       <!-- 비밀번호 분실 경고 (setup 모드) -->
       <div v-if="mode === 'setup'" class="warning-box">
         <AlertTriangle :size="16" class="warning-icon"/>
-        <span>비밀번호를 분실하면 데이터를 복구할 수 없습니다. 반드시 안전한 곳에 보관하세요.</span>
+        <span>비밀번호를 분실하면 데이터를 절대로 복구할 수 없습니다. 반드시 안전한 곳에 보관하세요.</span>
       </div>
 
       <div class="form">

--- a/src/components/WorkspaceSidebar.vue
+++ b/src/components/WorkspaceSidebar.vue
@@ -14,6 +14,7 @@ import {
   PenLine,
   Replace,
   ScanSearch,
+  Settings,
   Upload,
   Users,
 } from 'lucide-vue-next'
@@ -74,6 +75,11 @@ const navGroups = [
       {id: 'import', label: '가져오기(Import)', icon: Download},
       {id: 'export', label: '내보내기(Export)', icon: Upload},
       {id: 'checklist', label: '체크리스트(Checklist)', icon: ClipboardList},
+    ],
+  },
+  {
+    items: [
+      {id: 'settings', label: '설정(Settings)', icon: Settings},
     ],
   },
 ]

--- a/src/components/WorkspaceSidebar.vue
+++ b/src/components/WorkspaceSidebar.vue
@@ -77,11 +77,6 @@ const navGroups = [
       {id: 'checklist', label: '체크리스트(Checklist)', icon: ClipboardList},
     ],
   },
-  {
-    items: [
-      {id: 'settings', label: '설정(Settings)', icon: Settings},
-    ],
-  },
 ]
 </script>
 
@@ -142,6 +137,20 @@ const navGroups = [
       >
         <GitBranch :size="20" class="autosave-icon"/>
         <span v-if="!collapsed" class="autosave-text">스냅샷(Snapshot)</span>
+      </button>
+
+      <!-- 설정 버튼 -->
+      <button
+          class="autosave-indicator"
+          :class="[
+            { 'autosave-indicator--icon': collapsed },
+            activeSection === 'settings' ? 'footer-btn--active' : ''
+          ]"
+          @click="select('settings')"
+          title="설정(Settings)"
+      >
+        <Settings :size="20" class="autosave-icon"/>
+        <span v-if="!collapsed" class="autosave-text">설정(Settings)</span>
       </button>
     </div>
   </aside>
@@ -282,7 +291,10 @@ const navGroups = [
 
 /* 하단 */
 .sidebar-footer {
+  display: flex;
+  flex-direction: column;
   padding: 8px;
+  gap: 5px;
 }
 
 .footer-divider {
@@ -366,5 +378,20 @@ const navGroups = [
 .sidebar--collapsed .file-btn {
   justify-content: center;
   padding: 8px;
+}
+
+.footer-btn--active {
+  background-color: rgba(59, 91, 219, 0.2);
+  color: #93c5fd;
+}
+
+.footer-btn--active:hover {
+  background-color: rgba(59, 91, 219, 0.3);
+  color: #bfdbfe;
+}
+
+.footer-btn--active .autosave-icon {
+  color: #93c5fd;
+  opacity: 1;
 }
 </style>

--- a/src/sections/SettingsSection.vue
+++ b/src/sections/SettingsSection.vue
@@ -1,0 +1,305 @@
+<script setup>
+import { ref } from 'vue'
+import { Shield, ShieldOff, KeyRound, AlertTriangle } from 'lucide-vue-next'
+import { useConfigStore } from '../stores/configStore'
+import PasswordModal from '../components/PasswordModal.vue'
+
+const config = useConfigStore()
+
+const showPasswordModal = ref(false)
+const passwordModalMode = ref('setup')
+const passwordError = ref('')
+const passwordLoading = ref(false)
+const statusMessage = ref('')
+
+function openSetup() {
+  passwordModalMode.value = 'setup'
+  passwordError.value = ''
+  statusMessage.value = ''
+  showPasswordModal.value = true
+}
+
+function openChange() {
+  passwordModalMode.value = 'change'
+  passwordError.value = ''
+  statusMessage.value = ''
+  showPasswordModal.value = true
+}
+
+async function handleDisable() {
+  if (!confirm('암호화를 비활성화하면 데이터가 평문으로 저장됩니다. 계속하시겠습니까?')) return
+  statusMessage.value = ''
+  try {
+    await config.disableEncryption()
+    statusMessage.value = '암호화가 비활성화되었습니다.'
+  } catch (e) {
+    statusMessage.value = '오류: ' + String(e)
+  }
+}
+
+async function handlePasswordSubmit(payload) {
+  passwordError.value = ''
+  passwordLoading.value = true
+  try {
+    if (passwordModalMode.value === 'setup') {
+      await config.enableEncryption(payload.password)
+      statusMessage.value = '암호화가 활성화되었습니다.'
+    } else {
+      await config.changeEncryptionPassword(payload.oldPassword, payload.newPassword)
+      statusMessage.value = '비밀번호가 변경되었습니다.'
+    }
+    showPasswordModal.value = false
+  } catch (e) {
+    passwordError.value = String(e)
+  } finally {
+    passwordLoading.value = false
+  }
+}
+</script>
+
+<template>
+  <div class="settings-section">
+    <div class="section-header">
+      <h2 class="section-title">설정(Settings)</h2>
+      <p class="section-desc">파일 및 보안 설정을 관리합니다.</p>
+    </div>
+
+    <!-- 암호화 설정 카드 -->
+    <div class="settings-card">
+      <div class="card-header">
+        <div class="card-icon" :class="config.encryptionEnabled ? 'icon-enabled' : 'icon-disabled'">
+          <Shield v-if="config.encryptionEnabled" :size="20"/>
+          <ShieldOff v-else :size="20"/>
+        </div>
+        <div>
+          <h3 class="card-title">데이터 암호화</h3>
+          <p class="card-desc">학생 이름과 생기부 내용을 암호화합니다.</p>
+        </div>
+        <div class="card-badge" :class="config.encryptionEnabled ? 'badge-on' : 'badge-off'">
+          {{ config.encryptionEnabled ? '활성화' : '비활성화' }}
+        </div>
+      </div>
+
+      <!-- 경고 문구 -->
+      <div class="warning-box">
+        <AlertTriangle :size="14" class="warning-icon"/>
+        <span>암호화 활성화 시 비밀번호를 분실하면 데이터를 복구할 수 없습니다.</span>
+      </div>
+
+      <!-- 버튼 -->
+      <div class="card-actions">
+        <button v-if="!config.encryptionEnabled" class="btn-enable" @click="openSetup">
+          <Shield :size="16"/>
+          암호화 활성화
+        </button>
+        <template v-else>
+          <button class="btn-change" @click="openChange">
+            <KeyRound :size="16"/>
+            비밀번호 변경
+          </button>
+          <button class="btn-disable" @click="handleDisable">
+            <ShieldOff :size="16"/>
+            암호화 비활성화
+          </button>
+        </template>
+      </div>
+
+      <!-- 상태 메시지 -->
+      <transition name="fade">
+        <p v-if="statusMessage" class="status-msg" :class="statusMessage.startsWith('오류') ? 'status-error' : 'status-ok'">
+          {{ statusMessage }}
+        </p>
+      </transition>
+    </div>
+
+    <!-- 비밀번호 모달 -->
+    <PasswordModal
+        v-if="showPasswordModal"
+        :mode="passwordModalMode"
+        :error="passwordError"
+        :loading="passwordLoading"
+        @submit="handlePasswordSubmit"
+        @cancel="showPasswordModal = false"
+    />
+  </div>
+</template>
+
+<style scoped>
+.settings-section {
+  padding: 32px;
+  max-width: 720px;
+}
+
+.section-header {
+  margin-bottom: 28px;
+}
+
+.section-title {
+  font-size: 22px;
+  font-weight: 700;
+  color: #e2e8f0;
+  margin: 0 0 6px;
+}
+
+.section-desc {
+  font-size: 15px;
+  color: var(--clr-text-hint);
+  margin: 0;
+}
+
+.settings-card {
+  background-color: #0e1524;
+  border: 1px solid #1e2d45;
+  border-radius: 16px;
+  padding: 24px;
+}
+
+.card-header {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.card-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  border-radius: 12px;
+  flex-shrink: 0;
+}
+
+.icon-enabled {
+  background-color: rgba(16, 185, 129, 0.12);
+  border: 1px solid rgba(16, 185, 129, 0.3);
+  color: #34d399;
+}
+
+.icon-disabled {
+  background-color: rgba(100, 116, 139, 0.12);
+  border: 1px solid rgba(100, 116, 139, 0.3);
+  color: #64748b;
+}
+
+.card-title {
+  font-size: 16px;
+  font-weight: 600;
+  color: #e2e8f0;
+  margin: 0 0 4px;
+}
+
+.card-desc {
+  font-size: 14px;
+  color: var(--clr-text-hint);
+  margin: 0;
+}
+
+.card-badge {
+  margin-left: auto;
+  padding: 4px 12px;
+  border-radius: 20px;
+  font-size: 13px;
+  font-weight: 600;
+  flex-shrink: 0;
+}
+
+.badge-on {
+  background-color: rgba(16, 185, 129, 0.12);
+  border: 1px solid rgba(16, 185, 129, 0.3);
+  color: #34d399;
+}
+
+.badge-off {
+  background-color: rgba(100, 116, 139, 0.1);
+  border: 1px solid rgba(100, 116, 139, 0.25);
+  color: #64748b;
+}
+
+.warning-box {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 10px 14px;
+  border-radius: 10px;
+  background-color: rgba(245, 158, 11, 0.07);
+  border: 1px solid rgba(245, 158, 11, 0.2);
+  font-size: 13px;
+  color: #fbbf24;
+  line-height: 1.5;
+  margin-bottom: 18px;
+}
+
+.warning-icon {
+  flex-shrink: 0;
+  margin-top: 1px;
+}
+
+.card-actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.btn-enable,
+.btn-change,
+.btn-disable {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 9px 18px;
+  border-radius: 10px;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background-color 0.15s, transform 0.1s;
+  border: 1px solid transparent;
+}
+
+.btn-enable:active, .btn-change:active, .btn-disable:active {
+  transform: scale(0.97);
+}
+
+.btn-enable {
+  background-color: rgba(16, 185, 129, 0.15);
+  border-color: rgba(16, 185, 129, 0.35);
+  color: #34d399;
+}
+
+.btn-enable:hover {
+  background-color: rgba(16, 185, 129, 0.25);
+}
+
+.btn-change {
+  background-color: rgba(59, 91, 219, 0.15);
+  border-color: rgba(59, 91, 219, 0.35);
+  color: #6ea8fe;
+}
+
+.btn-change:hover {
+  background-color: rgba(59, 91, 219, 0.25);
+}
+
+.btn-disable {
+  background-color: rgba(239, 68, 68, 0.1);
+  border-color: rgba(239, 68, 68, 0.3);
+  color: #fca5a5;
+}
+
+.btn-disable:hover {
+  background-color: rgba(239, 68, 68, 0.18);
+}
+
+.status-msg {
+  margin: 14px 0 0;
+  font-size: 14px;
+  font-weight: 500;
+}
+
+.status-ok { color: #34d399; }
+.status-error { color: #fca5a5; }
+
+.fade-enter-from, .fade-leave-to { opacity: 0; }
+.fade-enter-active, .fade-leave-active { transition: opacity 0.3s; }
+</style>

--- a/src/sections/SettingsSection.vue
+++ b/src/sections/SettingsSection.vue
@@ -1,7 +1,7 @@
 <script setup>
-import { ref } from 'vue'
-import { Shield, ShieldOff, KeyRound, AlertTriangle } from 'lucide-vue-next'
-import { useConfigStore } from '../stores/configStore'
+import {ref} from 'vue'
+import {AlertTriangle, KeyRound, Shield, ShieldOff} from 'lucide-vue-next'
+import {useConfigStore} from '../stores/configStore'
 import PasswordModal from '../components/PasswordModal.vue'
 
 const config = useConfigStore()
@@ -58,58 +58,64 @@ async function handlePasswordSubmit(payload) {
 </script>
 
 <template>
-  <div class="settings-section">
+  <div class="section">
     <div class="section-header">
-      <h2 class="section-title">설정(Settings)</h2>
-      <p class="section-desc">파일 및 보안 설정을 관리합니다.</p>
+      <div>
+        <h2 class="section-title">설정(Settings)</h2>
+        <p class="section-desc">파일 및 보안 설정을 관리합니다.</p>
+      </div>
     </div>
 
-    <!-- 암호화 설정 카드 -->
-    <div class="settings-card">
-      <div class="card-header">
-        <div class="card-icon" :class="config.encryptionEnabled ? 'icon-enabled' : 'icon-disabled'">
-          <Shield v-if="config.encryptionEnabled" :size="20"/>
-          <ShieldOff v-else :size="20"/>
-        </div>
-        <div>
-          <h3 class="card-title">데이터 암호화</h3>
-          <p class="card-desc">학생 이름과 생기부 내용을 암호화합니다.</p>
-        </div>
-        <div class="card-badge" :class="config.encryptionEnabled ? 'badge-on' : 'badge-off'">
-          {{ config.encryptionEnabled ? '활성화' : '비활성화' }}
-        </div>
-      </div>
+    <div class="section-body">
 
-      <!-- 경고 문구 -->
-      <div class="warning-box">
-        <AlertTriangle :size="14" class="warning-icon"/>
-        <span>암호화 활성화 시 비밀번호를 분실하면 데이터를 복구할 수 없습니다.</span>
-      </div>
+      <!-- 암호화 설정 카드 -->
+      <div class="settings-card">
+        <div class="card-header">
+          <div class="card-icon" :class="config.encryptionEnabled ? 'icon-enabled' : 'icon-disabled'">
+            <Shield v-if="config.encryptionEnabled" :size="20"/>
+            <ShieldOff v-else :size="20"/>
+          </div>
+          <div>
+            <h3 class="card-title">데이터 암호화</h3>
+            <p class="card-desc">학생 이름과 생기부 내용을 암호화합니다.</p>
+          </div>
+          <div class="card-badge" :class="config.encryptionEnabled ? 'badge-on' : 'badge-off'">
+            {{ config.encryptionEnabled ? '활성화' : '비활성화' }}
+          </div>
+        </div>
 
-      <!-- 버튼 -->
-      <div class="card-actions">
-        <button v-if="!config.encryptionEnabled" class="btn-enable" @click="openSetup">
-          <Shield :size="16"/>
-          암호화 활성화
-        </button>
-        <template v-else>
-          <button class="btn-change" @click="openChange">
-            <KeyRound :size="16"/>
-            비밀번호 변경
+        <!-- 경고 문구 -->
+        <div class="warning-box">
+          <AlertTriangle :size="14" class="warning-icon"/>
+          <span>암호화 활성화 시 비밀번호를 분실하면 데이터를 복구할 수 없습니다.</span>
+        </div>
+
+        <!-- 버튼 -->
+        <div class="card-actions">
+          <button v-if="!config.encryptionEnabled" class="btn-enable" @click="openSetup">
+            <Shield :size="16"/>
+            암호화 활성화
           </button>
-          <button class="btn-disable" @click="handleDisable">
-            <ShieldOff :size="16"/>
-            암호화 비활성화
-          </button>
-        </template>
-      </div>
+          <template v-else>
+            <button class="btn-change" @click="openChange">
+              <KeyRound :size="16"/>
+              비밀번호 변경
+            </button>
+            <button class="btn-disable" @click="handleDisable">
+              <ShieldOff :size="16"/>
+              암호화 비활성화
+            </button>
+          </template>
+        </div>
 
-      <!-- 상태 메시지 -->
-      <transition name="fade">
-        <p v-if="statusMessage" class="status-msg" :class="statusMessage.startsWith('오류') ? 'status-error' : 'status-ok'">
-          {{ statusMessage }}
-        </p>
-      </transition>
+        <!-- 상태 메시지 -->
+        <transition name="fade">
+          <p v-if="statusMessage" class="status-msg"
+             :class="statusMessage.startsWith('오류') ? 'status-error' : 'status-ok'">
+            {{ statusMessage }}
+          </p>
+        </transition>
+      </div>
     </div>
 
     <!-- 비밀번호 모달 -->
@@ -125,13 +131,28 @@ async function handlePasswordSubmit(payload) {
 </template>
 
 <style scoped>
-.settings-section {
-  padding: 32px;
-  max-width: 720px;
+.section {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+  box-sizing: border-box;
+}
+
+.section-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 32px 40px 48px;
 }
 
 .section-header {
-  margin-bottom: 28px;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  padding: 36px 40px;
+  border-bottom: 1px solid #1a2035;
+  flex-shrink: 0;
+  gap: 16px;
 }
 
 .section-title {
@@ -142,8 +163,8 @@ async function handlePasswordSubmit(payload) {
 }
 
 .section-desc {
-  font-size: 15px;
-  color: var(--clr-text-hint);
+  font-size: 16px;
+  color: #7ba3d4;
   margin: 0;
 }
 
@@ -297,9 +318,19 @@ async function handlePasswordSubmit(payload) {
   font-weight: 500;
 }
 
-.status-ok { color: #34d399; }
-.status-error { color: #fca5a5; }
+.status-ok {
+  color: #34d399;
+}
 
-.fade-enter-from, .fade-leave-to { opacity: 0; }
-.fade-enter-active, .fade-leave-active { transition: opacity 0.3s; }
+.status-error {
+  color: #fca5a5;
+}
+
+.fade-enter-from, .fade-leave-to {
+  opacity: 0;
+}
+
+.fade-enter-active, .fade-leave-active {
+  transition: opacity 0.3s;
+}
 </style>

--- a/src/sections/SettingsSection.vue
+++ b/src/sections/SettingsSection.vue
@@ -10,35 +10,39 @@ const showPasswordModal = ref(false)
 const passwordModalMode = ref('setup')
 const passwordError = ref('')
 const passwordLoading = ref(false)
-const statusMessage = ref('')
-const confirmDisable = ref(false)
+const statusEncryptMessage = ref('')
+const confirmEncryptDisable = ref(false)
+const disableEncryptLoading = ref(false)
 
 function openSetup() {
   passwordModalMode.value = 'setup'
   passwordError.value = ''
-  statusMessage.value = ''
+  statusEncryptMessage.value = ''
   showPasswordModal.value = true
 }
 
 function openChange() {
   passwordModalMode.value = 'change'
   passwordError.value = ''
-  statusMessage.value = ''
+  statusEncryptMessage.value = ''
   showPasswordModal.value = true
 }
 
 async function handleDisable() {
-  if (!confirmDisable.value) {
-    confirmDisable.value = true
+  if (!confirmEncryptDisable.value) {
+    confirmEncryptDisable.value = true
     return
   }
-  confirmDisable.value = false
-  statusMessage.value = ''
+  confirmEncryptDisable.value = false
+  disableEncryptLoading.value = true
+  statusEncryptMessage.value = ''
   try {
     await config.disableEncryption()
-    statusMessage.value = '암호화가 비활성화되었습니다.'
+    statusEncryptMessage.value = '암호화가 비활성화되었습니다.'
   } catch (e) {
-    statusMessage.value = '오류: ' + String(e)
+    statusEncryptMessage.value = '오류: ' + String(e)
+  } finally {
+    disableEncryptLoading.value = false
   }
 }
 
@@ -48,10 +52,10 @@ async function handlePasswordSubmit(payload) {
   try {
     if (passwordModalMode.value === 'setup') {
       await config.enableEncryption(payload.password)
-      statusMessage.value = '암호화가 활성화되었습니다.'
+      statusEncryptMessage.value = '암호화가 활성화되었습니다.'
     } else {
       await config.changeEncryptionPassword(payload.oldPassword, payload.newPassword)
-      statusMessage.value = '비밀번호가 변경되었습니다.'
+      statusEncryptMessage.value = '비밀번호가 변경되었습니다.'
     }
     showPasswordModal.value = false
   } catch (e) {
@@ -102,11 +106,11 @@ async function handlePasswordSubmit(payload) {
             암호화 활성화
           </button>
           <template v-else>
-            <button class="btn-change" @click="openChange">
+            <button class="btn-change" :disabled="disableEncryptLoading" @click="openChange">
               <KeyRound :size="16"/>
               비밀번호 변경
             </button>
-            <button v-if="!confirmDisable" class="btn-disable" @click="handleDisable">
+            <button v-if="!confirmEncryptDisable" class="btn-disable" :disabled="disableEncryptLoading" @click="handleDisable">
               <ShieldOff :size="16"/>
               암호화 비활성화
             </button>
@@ -116,8 +120,10 @@ async function handlePasswordSubmit(payload) {
                 <span class="disable-warning-title">암호화를 정말 비활성화하시겠습니까?</span>
               </div>
               <div class="disable-confirm-btns">
-                <button class="btn-cancel-sm" @click="confirmDisable = false">취소</button>
-                <button class="btn-disable-confirm" @click="handleDisable">비활성화</button>
+                <button class="btn-cancel-sm" :disabled="disableEncryptLoading" @click="confirmEncryptDisable = false">취소</button>
+                <button class="btn-disable-confirm" :disabled="disableEncryptLoading" @click="handleDisable">
+                  {{ disableEncryptLoading ? '처리 중…' : '비활성화' }}
+                </button>
               </div>
             </div>
           </template>
@@ -125,9 +131,9 @@ async function handlePasswordSubmit(payload) {
 
         <!-- 상태 메시지 -->
         <transition name="fade">
-          <p v-if="statusMessage" class="status-msg"
-             :class="statusMessage.startsWith('오류') ? 'status-error' : 'status-ok'">
-            {{ statusMessage }}
+          <p v-if="statusEncryptMessage" class="status-msg"
+             :class="statusEncryptMessage.startsWith('오류') ? 'status-error' : 'status-ok'">
+            {{ statusEncryptMessage }}
           </p>
         </transition>
       </div>

--- a/src/sections/SettingsSection.vue
+++ b/src/sections/SettingsSection.vue
@@ -11,6 +11,7 @@ const passwordModalMode = ref('setup')
 const passwordError = ref('')
 const passwordLoading = ref(false)
 const statusMessage = ref('')
+const confirmDisable = ref(false)
 
 function openSetup() {
   passwordModalMode.value = 'setup'
@@ -27,7 +28,11 @@ function openChange() {
 }
 
 async function handleDisable() {
-  if (!confirm('암호화를 비활성화하면 데이터가 평문으로 저장됩니다. 계속하시겠습니까?')) return
+  if (!confirmDisable.value) {
+    confirmDisable.value = true
+    return
+  }
+  confirmDisable.value = false
   statusMessage.value = ''
   try {
     await config.disableEncryption()
@@ -101,10 +106,20 @@ async function handlePasswordSubmit(payload) {
               <KeyRound :size="16"/>
               비밀번호 변경
             </button>
-            <button class="btn-disable" @click="handleDisable">
+            <button v-if="!confirmDisable" class="btn-disable" @click="handleDisable">
               <ShieldOff :size="16"/>
               암호화 비활성화
             </button>
+            <div v-else class="disable-confirm-row">
+              <div class="disable-warning">
+                <AlertTriangle :size="14" class="disable-warning-icon"/>
+                <span class="disable-warning-title">암호화를 정말 비활성화하시겠습니까?</span>
+              </div>
+              <div class="disable-confirm-btns">
+                <button class="btn-cancel-sm" @click="confirmDisable = false">취소</button>
+                <button class="btn-disable-confirm" @click="handleDisable">비활성화</button>
+              </div>
+            </div>
           </template>
         </div>
 
@@ -324,6 +339,72 @@ async function handlePasswordSubmit(payload) {
 
 .status-error {
   color: #fca5a5;
+}
+
+.disable-confirm-row {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 10px;
+}
+
+.disable-warning {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background-color: rgba(239, 68, 68, 0.07);
+  border: 1px solid rgba(239, 68, 68, 0.25);
+  border-radius: 10px;
+  padding: 9px 18px;
+}
+
+.disable-warning-icon {
+  color: #f87171;
+  flex-shrink: 0;
+}
+
+.disable-warning-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: #f87171;
+}
+
+.disable-confirm-btns {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.btn-cancel-sm {
+  padding: 9px 18px;
+  border-radius: 8px;
+  border: 1px solid rgba(100, 116, 139, 0.4);
+  background: transparent;
+  color: #94a3b8;
+  font-size: 14px;
+  cursor: pointer;
+  box-sizing: border-box;
+}
+
+.btn-cancel-sm:hover {
+  background-color: rgba(100, 116, 139, 0.12);
+}
+
+.btn-disable-confirm {
+  padding: 9px 18px;
+  border-radius: 8px;
+  border: 1px solid transparent;
+  background-color: #ef4444;
+  color: white;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.15s;
+  box-sizing: border-box;
+}
+
+.btn-disable-confirm:hover {
+  background-color: #dc2626;
 }
 
 .fade-enter-from, .fade-leave-to {

--- a/src/sections/SettingsSection.vue
+++ b/src/sections/SettingsSection.vue
@@ -299,7 +299,9 @@ async function handlePasswordSubmit(payload) {
   border: 1px solid transparent;
 }
 
-.btn-enable:active, .btn-change:active, .btn-disable:active {
+.btn-enable:active:not(:disabled),
+.btn-change:active:not(:disabled),
+.btn-disable:active:not(:disabled) {
   transform: scale(0.97);
 }
 
@@ -411,6 +413,16 @@ async function handlePasswordSubmit(payload) {
 
 .btn-disable-confirm:hover {
   background-color: #dc2626;
+}
+
+.btn-enable:disabled,
+.btn-change:disabled,
+.btn-disable:disabled,
+.btn-cancel-sm:disabled,
+.btn-disable-confirm:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+  pointer-events: none;
 }
 
 .fade-enter-from, .fade-leave-to {

--- a/src/sections/SettingsSection.vue
+++ b/src/sections/SettingsSection.vue
@@ -71,7 +71,7 @@ async function handlePasswordSubmit(payload) {
     <div class="section-header">
       <div>
         <h2 class="section-title">설정(Settings)</h2>
-        <p class="section-desc">파일 및 보안 설정을 관리합니다.</p>
+        <p class="section-desc">프로그램의 기본 설정을 관리합니다.</p>
       </div>
     </div>
 
@@ -86,7 +86,7 @@ async function handlePasswordSubmit(payload) {
           </div>
           <div>
             <h3 class="card-title">데이터 암호화</h3>
-            <p class="card-desc">학생 이름과 생기부 내용을 암호화합니다.</p>
+            <p class="card-desc">학생 개인정보와 학교생활기록부 내용을 암호화하여 보호합니다.</p>
           </div>
           <div class="card-badge" :class="config.encryptionEnabled ? 'badge-on' : 'badge-off'">
             {{ config.encryptionEnabled ? '활성화' : '비활성화' }}

--- a/src/stores/configStore.js
+++ b/src/stores/configStore.js
@@ -7,6 +7,8 @@ const DEFAULT_CELL_SIZE = 14
 
 export const useConfigStore = defineStore('config', () => {
     const recordCellFontSize = ref(DEFAULT_CELL_SIZE)
+    const encryptionEnabled = ref(false)
+    const encryptionUnlocked = ref(false)
 
     async function loadAll() {
         const val = await invoke('get_config', { key: RECORD_CELL_SIZE_KEY })
@@ -14,6 +16,10 @@ export const useConfigStore = defineStore('config', () => {
             const parsed = parseInt(val, 10)
             if (!isNaN(parsed)) recordCellFontSize.value = parsed
         }
+
+        const status = await invoke('get_encryption_status')
+        encryptionEnabled.value = status.enabled
+        encryptionUnlocked.value = status.unlocked
     }
 
     async function setRecordCellFontSize(size) {
@@ -21,5 +27,36 @@ export const useConfigStore = defineStore('config', () => {
         await invoke('set_config', { key: RECORD_CELL_SIZE_KEY, value: String(size) })
     }
 
-    return { recordCellFontSize, loadAll, setRecordCellFontSize }
+    async function unlockEncryption(password) {
+        await invoke('unlock_encryption', { password })
+        encryptionUnlocked.value = true
+    }
+
+    async function enableEncryption(password) {
+        await invoke('enable_encryption', { password })
+        encryptionEnabled.value = true
+        encryptionUnlocked.value = true
+    }
+
+    async function disableEncryption() {
+        await invoke('disable_encryption')
+        encryptionEnabled.value = false
+        encryptionUnlocked.value = false
+    }
+
+    async function changeEncryptionPassword(oldPassword, newPassword) {
+        await invoke('change_encryption_password', { oldPassword, newPassword })
+    }
+
+    return {
+        recordCellFontSize,
+        encryptionEnabled,
+        encryptionUnlocked,
+        loadAll,
+        setRecordCellFontSize,
+        unlockEncryption,
+        enableEncryption,
+        disableEncryption,
+        changeEncryptionPassword,
+    }
 })

--- a/src/stores/configStore.js
+++ b/src/stores/configStore.js
@@ -11,12 +11,19 @@ export const useConfigStore = defineStore('config', () => {
     const encryptionUnlocked = ref(false)
 
     async function loadAll() {
+        await loadPreferences()
+        await refreshEncryptionStatus()
+    }
+
+    async function loadPreferences() {
         const val = await invoke('get_config', { key: RECORD_CELL_SIZE_KEY })
         if (val !== null && val !== undefined) {
             const parsed = parseInt(val, 10)
             if (!isNaN(parsed)) recordCellFontSize.value = parsed
         }
+    }
 
+    async function refreshEncryptionStatus() {
         const status = await invoke('get_encryption_status')
         encryptionEnabled.value = status.enabled
         encryptionUnlocked.value = status.unlocked
@@ -29,23 +36,22 @@ export const useConfigStore = defineStore('config', () => {
 
     async function unlockEncryption(password) {
         await invoke('unlock_encryption', { password })
-        encryptionUnlocked.value = true
+        await refreshEncryptionStatus()
     }
 
     async function enableEncryption(password) {
         await invoke('enable_encryption', { password })
-        encryptionEnabled.value = true
-        encryptionUnlocked.value = true
+        await refreshEncryptionStatus()
     }
 
     async function disableEncryption() {
         await invoke('disable_encryption')
-        encryptionEnabled.value = false
-        encryptionUnlocked.value = false
+        await refreshEncryptionStatus()
     }
 
     async function changeEncryptionPassword(oldPassword, newPassword) {
         await invoke('change_encryption_password', { oldPassword, newPassword })
+        await refreshEncryptionStatus()
     }
 
     return {
@@ -53,6 +59,8 @@ export const useConfigStore = defineStore('config', () => {
         encryptionEnabled,
         encryptionUnlocked,
         loadAll,
+        loadPreferences,
+        refreshEncryptionStatus,
         setRecordCellFontSize,
         unlockEncryption,
         enableEncryption,

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -6,9 +6,12 @@ import {open, save} from '@tauri-apps/plugin-dialog'
 import {getVersion} from '@tauri-apps/api/app'
 import {openUrl} from '@tauri-apps/plugin-opener'
 import {useProjectStore} from '../stores/project'
+import {useConfigStore} from '../stores/configStore'
+import PasswordModal from '../components/PasswordModal.vue'
 
 const router = useRouter()
 const project = useProjectStore()
+const config = useConfigStore()
 const error = ref('')
 
 const currentVersion = ref('')
@@ -16,6 +19,11 @@ const showUpdateModal = ref(false)
 const updateStatus = ref('idle') // 'idle' | 'checking' | 'latest' | 'found' | 'error'
 const latestVersion = ref('')
 const releaseUrl = ref('')
+
+const showPasswordModal = ref(false)
+const passwordError = ref('')
+const passwordLoading = ref(false)
+let pendingPath = ''
 
 onMounted(async () => {
   currentVersion.value = await getVersion()
@@ -49,10 +57,37 @@ async function handleOpen() {
   try {
     await invoke('open_project', {path})
     project.setProject(path)
-    router.push('/workspace')
+    const status = await invoke('get_encryption_status')
+    if (status.enabled) {
+      pendingPath = path
+      passwordError.value = ''
+      showPasswordModal.value = true
+    } else {
+      router.push('/workspace')
+    }
   } catch (e) {
     error.value = String(e)
   }
+}
+
+async function handlePasswordSubmit({password}) {
+  passwordError.value = ''
+  passwordLoading.value = true
+  try {
+    await config.unlockEncryption(password)
+    showPasswordModal.value = false
+    router.push('/workspace')
+  } catch (e) {
+    passwordError.value = String(e)
+  } finally {
+    passwordLoading.value = false
+  }
+}
+
+function handlePasswordCancel() {
+  showPasswordModal.value = false
+  project.closeProject()
+  pendingPath = ''
 }
 
 async function checkUpdate() {
@@ -180,6 +215,16 @@ function closeUpdateModal() {
         </p>
       </div>
     </div>
+
+    <!-- 비밀번호 모달 -->
+    <PasswordModal
+        v-if="showPasswordModal"
+        mode="unlock"
+        :error="passwordError"
+        :loading="passwordLoading"
+        @submit="handlePasswordSubmit"
+        @cancel="handlePasswordCancel"
+    />
 
     <!-- 업데이트 모달 -->
     <transition name="modal">

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -23,7 +23,6 @@ const releaseUrl = ref('')
 const showPasswordModal = ref(false)
 const passwordError = ref('')
 const passwordLoading = ref(false)
-let pendingPath = ''
 
 onMounted(async () => {
   currentVersion.value = await getVersion()
@@ -57,9 +56,8 @@ async function handleOpen() {
   try {
     await invoke('open_project', {path})
     project.setProject(path)
-    const status = await invoke('get_encryption_status')
-    if (status.enabled) {
-      pendingPath = path
+    await config.refreshEncryptionStatus()
+    if (config.encryptionEnabled) {
       passwordError.value = ''
       showPasswordModal.value = true
     } else {
@@ -87,7 +85,6 @@ async function handlePasswordSubmit({password}) {
 function handlePasswordCancel() {
   showPasswordModal.value = false
   project.closeProject()
-  pendingPath = ''
 }
 
 async function checkUpdate() {

--- a/src/views/WorkspaceView.vue
+++ b/src/views/WorkspaceView.vue
@@ -16,6 +16,7 @@ import ChecklistSection from '../sections/ChecklistSection.vue'
 import ReplaceSection from '../sections/ReplaceSection.vue'
 import InspectSection from '../sections/InspectSection.vue'
 import SnapshotModal from '../components/SnapshotModal.vue'
+import SettingsSection from '../sections/SettingsSection.vue'
 
 const project = useProjectStore()
 const config = useConfigStore()
@@ -35,6 +36,7 @@ const sectionMap = {
   checklist: ChecklistSection,
   replace: ReplaceSection,
   inspect: InspectSection,
+  settings: SettingsSection,
 }
 
 const currentSection = computed(() => sectionMap[activeSection.value])


### PR DESCRIPTION
안녕하세요, 선생님!
db 파일이 탈취되는 보안 사고 발생을 대비하여 암호화 기능을 새롭게 제안드립니다.

- PBKDF2-HMAC-SHA256으로 키 유도, AES-256-GCM으로 Student.name 및 ActivityRecord.content (+ 히스토리) 암호화
- 저장 형식: <nonce_b64>:<ciphertext_b64>
- PBKDF2 salt는 APP_CONFIGS에 보관, 파생 키는 세션 메모리(CryptoState)에 캐시
- enable/disable 시 전체 데이터 일괄 암복호화
- 파일 열기 시 encryption_enabled 확인 후 비밀번호 입력 요청
- replace/inspect/export 등 content 읽기·쓰기 전 과정에 암복호화 적용

감사합니다!